### PR TITLE
Support private Go modules in lint/test; parameterize git host (no hardcoded org)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -39,6 +39,11 @@ on:
         description: 'List of private Go modules'
         required: false
         default: ''
+      goprivate_git_host:
+        type: string
+        description: 'URL prefix (host or host/org) authenticated with GH_TOKEN when fetching private Go modules. Defaults to github.com (host-wide); set to e.g. github.com/my-org to scope narrower.'
+        required: false
+        default: 'github.com'
       additional_go_test_path:
         type: string
         required: false
@@ -96,7 +101,7 @@ jobs:
 
       - name: Set GitHub access token for GOPRIVATE
         if: ${{ inputs.GOPRIVATE }}
-        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@github.com/sneat-co".insteadOf "https://github.com/sneat-co"
+        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@${{ inputs.goprivate_git_host }}/".insteadOf "https://${{ inputs.goprivate_git_host }}/"
 
       - run: go get ./...
         shell: bash
@@ -152,7 +157,7 @@ jobs:
 
       - name: Set GitHub access token for GOPRIVATE
         if: ${{ inputs.GOPRIVATE }}
-        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@github.com/sneat-co".insteadOf "https://github.com/sneat-co"
+        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@${{ inputs.goprivate_git_host }}/".insteadOf "https://${{ inputs.goprivate_git_host }}/"
 
       - if: ${{ inputs.install-firebase-tools }}
         name: Set up Java JRE 24
@@ -239,7 +244,7 @@ jobs:
 
       - name: Set GitHub access token for GOPRIVATE
         if: ${{ inputs.GOPRIVATE }}
-        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@github.com/sneat-co".insteadOf "https://github.com/sneat-co"
+        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@${{ inputs.goprivate_git_host }}/".insteadOf "https://${{ inputs.goprivate_git_host }}/"
 
       - run: go get ./...
         shell: bash

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -94,6 +94,10 @@ jobs:
           go-version: '1.26'
           cache-dependency-path: ${{ inputs.working_directory }}/go.sum
 
+      - name: Set GitHub access token for GOPRIVATE
+        if: ${{ inputs.GOPRIVATE }}
+        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@github.com/sneat-co".insteadOf "https://github.com/sneat-co"
+
       - run: go get ./...
         shell: bash
         env:
@@ -145,6 +149,10 @@ jobs:
         with:
           go-version: '1.26'
           cache-dependency-path: ${{ inputs.working_directory }}/go.sum
+
+      - name: Set GitHub access token for GOPRIVATE
+        if: ${{ inputs.GOPRIVATE }}
+        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@github.com/sneat-co".insteadOf "https://github.com/sneat-co"
 
       - if: ${{ inputs.install-firebase-tools }}
         name: Set up Java JRE 24


### PR DESCRIPTION
Two related fixes to private-module support:

1. **Auth in all jobs** — the GOPRIVATE git-auth (`git config insteadOf`) step existed only in `go_build`, so `go_lint` and `go_test` couldn't fetch private modules ('could not read Username'). Added the same conditional step to both.

2. **No hardcoded org** — the step hardcoded `github.com/sneat-co`, wrong for a shared action. Replaced with a new `goprivate_git_host` input (default `github.com`, host-wide) used by all three jobs.

**Backwards compatible:** the auth step is gated on `GOPRIVATE` (no-op otherwise); the default `github.com` covers any org including sneat-co, so existing consumers are unaffected, and consumers using GOPRIVATE for other orgs now work too (previously they'd fail). Consumers can scope narrower via `with: goprivate_git_host: github.com/my-org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)