### PR TITLE
feat(release): support GOPRIVATE token so GoReleaser can fetch private deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,31 @@ name: Release
 
 on:
   workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: false
+        description: >-
+          Token with read access to private Go modules. Used in the git URL
+          username slot so GOPRIVATE fetches (e.g. GoReleaser's `go mod tidy`
+          before-hook) can pull private dependencies. Only needed when GOPRIVATE
+          is set; omit for repos with only public dependencies.
+    inputs:
+      GOPRIVATE:
+        type: string
+        required: false
+        default: ''
+        description: >-
+          Comma-separated private Go module path prefixes. Sets GOPRIVATE for go
+          commands run during release (notably GoReleaser before-hooks). Leave
+          empty for repos with only public dependencies.
+      goprivate_git_host:
+        type: string
+        required: false
+        default: 'github.com'
+        description: >-
+          URL prefix (host or host/org) authenticated with GH_TOKEN when fetching
+          private Go modules. Defaults to github.com; set e.g. github.com/my-org
+          to scope the token URL-rewrite narrower.
 #  push:
 #    tags:
 #      - 'v*.*.*'   # triggers only on tags like v1.26.0
@@ -24,6 +49,13 @@ jobs:
         with:
           go-version: '1.26'   # adjust to your project Go version
 
+      # Authenticate private-module fetches (GoReleaser's `go mod tidy` hook runs
+      # BEFORE the build and will fail to reach private deps otherwise). No-op for
+      # repos that don't pass GOPRIVATE.
+      - name: Set GitHub access token for GOPRIVATE
+        if: ${{ inputs.GOPRIVATE }}
+        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@${{ inputs.goprivate_git_host }}/".insteadOf "https://${{ inputs.goprivate_git_host }}/"
+
       - name: Bump version and push tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
@@ -39,3 +71,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # required for releases
+          GOPRIVATE: ${{ inputs.GOPRIVATE }}


### PR DESCRIPTION
GoReleaser's `before` hook runs `go mod tidy`, which fails for repos with **private** Go-module deps because the reusable release job never authenticated the fetch. (Surfaced by sneat-go after it added the private `sneat-co/requoter` dep — the on-main release failed at `hook failed: cmd=go`.)

Adds an optional `GH_TOKEN` secret + `GOPRIVATE`/`goprivate_git_host` inputs; when `GOPRIVATE` is set, configures `git insteadOf` with the token and exports `GOPRIVATE` to the GoReleaser step — mirroring what `workflow.yml` already does for lint/test/build.

**Backward compatible:** the new auth step is gated on `inputs.GOPRIVATE`, so public-only consumers (sneat-go-core, sneat-go-backend) are unaffected.

Approved by repo owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)