### PR TITLE
ci: point workflows at strongo/cicd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   strongo_workflow:
 #    permissions:
 #      contents: write
-    uses: strongo/go-ci-action/.github/workflows/workflow.yml@main
+    uses: strongo/cicd/.github/workflows/workflow.yml@main
 
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
strongo/go-ci-action was renamed to strongo/cicd (old refs redirect; this updates them explicitly). Trivial workflow-ref change.