### PR TITLE
feat: robust auto-tagging (fetch-depth 0) + @v1 pinning & Renovate preset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,12 @@ jobs:
       contents: write   # required for GoReleaser to push GitHub releases
 
     steps:
-      # 1. Checkout the code
+      # 1. Checkout the code with full history + all tags. Both GoReleaser (changelog /
+      #    "current tag" detection) and github-tag-action (deriving the next version from
+      #    commits since the last tag) fail or under-tag on the default shallow clone.
       - uses: actions/checkout@v7
-      #        with:
-      #          fetch-depth: 0  # fetch full history
-      #          tags: true       # fetch all tags
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v7
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,6 +77,16 @@ on:
         description: 'Allow automatic major version bump when a commit message contains the major string token. Disabled by default to prevent accidental major bumps.'
         required: false
         default: false
+      default_bump:
+        type: string
+        description: >-
+          Bump level applied when no conventional commit since the last tag implies one
+          (github-tag-action semantics). "patch" (the default, preserving prior behaviour)
+          cuts a patch release on every push/merge to main; set to "false" to only cut a
+          tag when the commits since the last tag contain feat:/fix:/BREAKING conventional
+          messages (no release for docs/chore/ci-only changes).
+        required: false
+        default: 'patch'
 
 jobs:
 
@@ -265,6 +275,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # Full history + all tags are REQUIRED by github-tag-action: it derives the next
+          # version from every conventional commit SINCE THE LAST TAG. With the default
+          # shallow clone (fetch-depth: 1) the action only sees HEAD's message, so a
+          # "Merge pull request #N ..." merge commit produces no bump and no tag even when
+          # the merged branch contained feat:/fix: commits. fetch-depth: 0 fixes that by
+          # letting the action evaluate the whole lastTag..HEAD range. (fetch-depth: 0
+          # fetches all tags too, so the previous version is always found.)
+          fetch-depth: 0
 
       - if: ${{ github.ref == 'refs/heads/main' }}
         id: tag_version
@@ -273,6 +292,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           tag_prefix: ${{ inputs.tag_prefix }}
+          default_bump: ${{ inputs.default_bump }}
           major_string_token: ${{ inputs.allow_major_version_bump && '#major' || '##no-major-bumps##' }}
           # fetch_all_tags: true - By default, this action fetch the last 100 tags from Github.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,144 @@
-# go-ci-action
-GitHub Action for Go continuous integration - get, vet, test, lint
+# strongo/cicd
+
+Shared CI/CD for Go repositories across the `strongo`, `dal-go`, `sneat-co`,
+`ingitdb`, and `bots-go-framework` orgs: reusable GitHub **workflows** and a
+composite **action** that run `get`, `vet`, `build`, `test`, `lint`, optional
+coverage, and automatic SemVer tagging.
+
+> **Renamed:** this repo was `strongo/go-ci-action`. GitHub redirects the old
+> path, so existing `uses: strongo/go-ci-action/...` references keep working.
+> New references should use `strongo/cicd`; the Renovate preset below migrates
+> the old name for you.
+
+## What's here
+
+| File | Kind | Purpose |
+| --- | --- | --- |
+| `.github/workflows/workflow.yml` | Reusable workflow (`workflow_call`) | Full Go CI: lint, test (+coverage), build, and version bump. The primary entry point. |
+| `.github/workflows/release.yml` | Reusable workflow (`workflow_call`) | GoReleaser release flow (tag + `goreleaser release`). |
+| `action.yml` | Composite action | Single-job CI for callers that want CI steps inline in their own job. |
+| `default.json` | Renovate preset | Shareable config consumers `extends` to auto-track this repo's tag (see below). |
+
+## Recommended usage: pin to a tag, not `@main`
+
+Pinning `@main` means one bad commit to the shared workflow breaks **every**
+consumer's CI at the same time — there is no blast-radius firebreak. Pin to a
+version tag instead:
+
+```yaml
+jobs:
+  ci:
+    uses: strongo/cicd/.github/workflows/workflow.yml@v1   # moving major tag
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Two pinning styles are supported:
+
+- **`@v1` — moving major tag (recommended default).** A lightweight tag that the
+  maintainer advances deliberately to the latest backward-compatible release.
+  You automatically get fixes without opening a PR, but a bad release only
+  reaches you when `v1` is advanced (not on every push to `main`).
+- **`@v1.x.y` — exact release (maximum control).** Pin an immutable release and
+  let **Renovate** open a PR to bump it (see below). Each bump runs through your
+  own CI before merging, giving you a full per-repo firebreak and an audit trail.
+
+`@main` still works and stays supported for backward compatibility, but is
+discouraged for the reasons above.
+
+> Existing `@main` consumers are **not** being mass-migrated. Adopt `@v1` (or the
+> Renovate preset) gradually, per repo, on your own schedule.
+
+## Keep the pin fresh with Renovate
+
+Add the shared preset to a consumer repo's `renovate.json` so Renovate keeps the
+`strongo/cicd` reference current — and rewrites any lingering
+`strongo/go-ci-action` reference onto `strongo/cicd@v1` — automatically:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "github>strongo/cicd"
+  ]
+}
+```
+
+The preset (`default.json` in this repo):
+
+- Groups and auto-updates the `strongo/cicd` reusable-workflow / action ref,
+  advancing `@v1.x.y` pins (and following the moving `@v1`) as releases are cut.
+- Auto-merges those bumps **through a PR gated by your CI**, so a broken release
+  fails your build and blocks the merge — the firebreak — instead of landing
+  silently.
+- Replaces legacy `strongo/go-ci-action` references with `strongo/cicd@v1`,
+  automating the rename find-and-replace.
+
+Override anything you like (e.g. disable `automerge`) in your own `renovate.json`
+after the `extends`.
+
+## Automatic version tagging
+
+On a push/merge to `main`, the `go_bump` job (workflow) / tag step (action) runs
+[`mathieudutour/github-tag-action`], which reads **conventional commits since the
+last tag** and pushes a new SemVer tag:
+
+| Commit type since last tag | Result |
+| --- | --- |
+| `fix:` | patch bump (`v1.2.3 → v1.2.4`) |
+| `feat:` | minor bump (`v1.2.3 → v1.3.0`) |
+| `feat!:` / `BREAKING CHANGE:` | major bump — only if `allow_major_version_bump: true` |
+| docs/chore/ci/refactor only | `default_bump` decides (see below) |
+
+### Required repo settings (read this — it's why tags were being missed)
+
+`github-tag-action` derives the bump from the commit range `lastTag..HEAD`. Two
+things must be true for it to see your `feat:`/`fix:` commits:
+
+1. **Full checkout.** The job checks out with **`fetch-depth: 0`** (fixed in this
+   repo). With the default shallow clone the action only sees `HEAD`'s message —
+   so a `Merge pull request #N …` merge commit (which is never
+   conventional-commit-shaped) produced **no bump and no tag**, even when the
+   merged branch was full of `feat:`/`fix:` commits. This was the cause of
+   releases needing hand-cut tags. If you consume the **composite `action.yml`**,
+   your *own* workflow must `actions/checkout` with `fetch-depth: 0`.
+
+2. **Conventional commits reach `main`.** Choose one, and set it in your repo's
+   **Settings → General → Pull Requests**:
+   - **Squash merge + "Default to PR title" for the squash commit message**, and
+     write conventional PR titles (`feat: …`, `fix: …`). The single squashed
+     commit is then conventional. *(Recommended — simplest and most robust.)*
+   - **Merge commits**, with conventional commits on your branches. `fetch-depth:
+     0` lets the action read them behind the merge commit.
+
+    Either way, enabling a linear-history / conventional-PR-title convention makes
+    tagging deterministic.
+
+### `default_bump` input
+
+Controls what happens when **no** commit since the last tag implies a bump
+(docs/chore/ci-only changes):
+
+- Reusable `workflow.yml`: **`default_bump: 'patch'`** by default (a push/merge to
+  `main` always cuts at least a patch tag — preserves prior behaviour). Set
+  `default_bump: 'false'` to tag *only* on `feat:`/`fix:`/breaking commits.
+- Composite `action.yml`: **`default_bump: 'false'`** by default (tags only on
+  conventional commits). Set to `'patch'`/`'minor'`/`'major'` to always bump.
+
+## Releasing this repo (maintainers)
+
+Tags are cut automatically by this repo's own CI (`v1.x.y`). To publish or advance
+the **moving `v1`** major tag after a release lands on `main`:
+
+```bash
+git fetch --tags origin
+# point v1 at the newest v1.x.y release (or origin/main)
+git tag -f v1 "$(git tag -l 'v1.*.*' | sort -V | tail -1)"
+git push -f origin v1
+```
+
+Advance `v1` only to releases you've verified are backward-compatible.
 
 <!-- dev-approach:v1 -->
 ## Our approach to development
@@ -13,3 +152,5 @@ We build with our own tooling:
 - **[cover100.dev](https://cover100.dev)** — drive toward 100% test coverage
 - **[DataTug](https://datatug.io)** — query & explore data
 <!-- /dev-approach -->
+
+[`mathieudutour/github-tag-action`]: https://github.com/mathieudutour/github-tag-action

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,16 @@ inputs:
     description: 'On push to main, bump and push a SemVer git tag (via conventional commits). Set to false for repos that manage versioning elsewhere (e.g. Nx Release in a monorepo). Requires contents:write when enabled.'
     required: false
     default: 'true'
+  default_bump:
+    description: >-
+      Bump level applied when no conventional commit since the last tag implies one.
+      "false" (default) cuts a tag only when the commits since the last tag contain
+      feat:/fix:/BREAKING messages; set to "patch"/"minor"/"major" to always bump on a
+      push to main. IMPORTANT: for tagging to see commits that sit BEHIND a merge commit,
+      the calling workflow MUST run actions/checkout with `fetch-depth: 0` (the default
+      shallow clone only exposes HEADs message). See the README.
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -86,7 +96,7 @@ runs:
       uses: mathieudutour/github-tag-action@v6.2
       with:
         github_token: ${{ inputs.github_token }}
-        default_bump: false
+        default_bump: ${{ inputs.default_bump }}
 
     - if: ${{ inputs.code_coverage }}
       name: Code coverage by Coveralls

--- a/default.json
+++ b/default.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Shared Renovate preset for repositories that consume strongo/cicd reusable workflows and the composite action. Extend it with `github>strongo/cicd` to (1) keep the strongo/cicd@vX ref current automatically and (2) migrate any legacy strongo/go-ci-action references onto strongo/cicd@v1 without a manual find-and-replace.",
+  "packageRules": [
+    {
+      "description": "Group and auto-update the strongo/cicd reusable-workflow / composite-action ref. This advances pinned @v1.x.y (and, when a consumer tracks it, follows the moving @v1) as new releases are cut. Each bump is a separate PR gated by the consumer's own CI, so a bad strongo/cicd release blocks that one repo instead of breaking every consumer at once - the firebreak that pinning @main lacks.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["strongo/cicd", "strongo/go-ci-action"],
+      "groupName": "strongo/cicd",
+      "automerge": true,
+      "automergeType": "pr",
+      "pinDigests": false
+    },
+    {
+      "description": "Automate the go-ci-action -> cicd rename: replace legacy strongo/go-ci-action references with strongo/cicd@v1. GitHub redirects keep the old path working at runtime, so this is a gradual, per-repo cleanup rather than a forced mass push.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["strongo/go-ci-action"],
+      "replacementName": "strongo/cicd",
+      "replacementVersion": "v1"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    "local>strongo/cicd"
   ]
 }


### PR DESCRIPTION
## What & why

Hardens the shared CI/CD repo on two fronts. **Backward compatible** — existing
`@main` consumers keep working, and no consumer repos are mass-migrated.

### (#4) Fix auto-tagging on merge commits

`mathieudutour/github-tag-action` derives the next SemVer from the conventional
commits in the `lastTag..HEAD` range. The `go_bump` (and release) jobs checked
out with the **default shallow clone (`fetch-depth: 1`)**, so the action only saw
`HEAD`'s message. A `Merge pull request #N …` commit is never
conventional-commit-shaped, so **no bump was derived and no tag was pushed** —
even when the merged branch was full of `feat:`/`fix:` commits. That's why
releases needed hand-cut tags (e.g. `ingitdb/v0.4.0`).

Evidence in this very repo: squash/Renovate commits whose *HEAD* is conventional
(`chore(deps): …`) produced `v1.6.1/2/3`, but the last **merge commit**
(`Merge pull request #26`) produced no tag.

**Fix:**
- `go_bump` (`workflow.yml`) and the release job (`release.yml`) now checkout with
  **`fetch-depth: 0`** → the action evaluates the whole `lastTag..HEAD` range and
  sees `feat:`/`fix:` commits behind a merge commit. (`fetch-depth: 0` also fixes
  a latent GoReleaser requirement in `release.yml`.)
- New **`default_bump`** input. `workflow.yml` defaults to `'patch'` (preserves
  prior behaviour: a push/merge to `main` cuts at least a patch); set `'false'` to
  tag **only** on `feat:`/`fix:`/`BREAKING`. `action.yml` defaults to `'false'`.
- README documents the **required repo setting**: squash-merge with conventional
  PR titles (recommended), or merge commits (now supported via `fetch-depth: 0`).

### (#3) `@v1` pinning + Renovate, without a mass push

Pinning `@main` (103 refs) means one bad commit breaks every consumer at once.

- **`default.json`** — a shareable Renovate preset. Consumers add
  `"extends": ["github>strongo/cicd"]` to (a) auto-advance the `strongo/cicd@vX`
  ref, each bump gated by that repo's own CI (per-repo firebreak), and (b)
  auto-migrate legacy `strongo/go-ci-action` refs to `strongo/cicd@v1`.
- **`renovate.json`** — `config:base` → `config:recommended`; dogfoods the preset.
- README recommends `@v1` (moving major) / `@v1.x.y` (Renovate-bumped) over
  `@main`, with consumer Renovate setup + the maintainer command to advance `v1`.

No `@main` → `@v1` mass push. Migration is opt-in, per repo, driven by Renovate.

## Verification

- All workflow/action YAML parse (ruby/psych); both JSON configs parse and pass
  the official `renovate-config-validator` ("Config validated successfully").
- Structural asserts confirm `go_bump` + release checkouts have `fetch-depth: 0`,
  and `default_bump` is wired to the new input (`workflow.yml` default `patch`,
  `action.yml` default `false`).
- Note: this PR's own CI references `workflow.yml@main` (self-referencing reusable
  workflows always resolve at `main`, not the PR head), so the PR run exercises
  *main's* workflow, not this branch's. The change is validated structurally above.

## ⚠️ Post-merge steps for the maintainer (do NOT do these pre-merge)

1. Merge this PR. The repo's own CI will auto-cut the next `v1.x.y` tag from this
   `feat:` commit (now that `fetch-depth: 0` is in effect).
2. Create / advance the **moving `v1`** major tag so consumers can pin `@v1`:

   ```bash
   git fetch --tags origin
   # point v1 at the newest v1.x.y release (or use origin/main)
   git tag -f v1 "$(git tag -l 'v1.*.*' | sort -V | tail -1)"
   git push -f origin v1
   ```

   (First-time creation doesn't strictly need `-f`; `-f` is required each later
   time you advance it.) Advance `v1` only to releases verified backward-compatible.

3. Gradually migrate consumers by adding the Renovate preset to each repo's
   `renovate.json` (or let Renovate onboard it) — no mass find-and-replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZythDmdpA3cm1pNdeirwp
