### PR TITLE
ci(release): forward publisher secrets + tag-push support in reusable release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,30 @@ on:
           username slot so GOPRIVATE fetches (e.g. GoReleaser's `go mod tidy`
           before-hook) can pull private dependencies. Only needed when GOPRIVATE
           is set; omit for repos with only public dependencies.
+      GORELEASER_GITHUB_TOKEN:
+        required: false
+        description: >-
+          Cross-repo PAT forwarded to GoReleaser as $GORELEASER_GITHUB_TOKEN.
+          Used by publishers that push to OTHER repos the default GITHUB_TOKEN
+          cannot reach — Homebrew tap/cask, Scoop bucket, and (unless a separate
+          WINGET_GITHUB_TOKEN is given) the WinGet fork. Reference it in your
+          `.goreleaser.yaml` as `{{ .Env.GORELEASER_GITHUB_TOKEN }}`. Omit for
+          repos whose only "publisher" is the GitHub release itself.
+      WINGET_GITHUB_TOKEN:
+        required: false
+        description: >-
+          Optional PAT forwarded to GoReleaser as $WINGET_GITHUB_TOKEN, for the
+          WinGet publisher's cross-fork PR to microsoft/winget-pkgs (needs a
+          classic PAT with `public_repo`). Provide only if it must differ from
+          GORELEASER_GITHUB_TOKEN; otherwise reference GORELEASER_GITHUB_TOKEN in
+          the winget block instead.
+      AUR_SSH_PRIVATE_KEY:
+        required: false
+        description: >-
+          Optional AUR SSH private key, forwarded to GoReleaser as
+          $AUR_SSH_PRIVATE_KEY. GoReleaser's `aurs` publisher accepts the key
+          contents directly (`private_key: {{ .Env.AUR_SSH_PRIVATE_KEY }}`); the
+          key must not be password-protected.
     inputs:
       GOPRIVATE:
         type: string
@@ -27,6 +51,29 @@ on:
           URL prefix (host or host/org) authenticated with GH_TOKEN when fetching
           private Go modules. Defaults to github.com; set e.g. github.com/my-org
           to scope the token URL-rewrite narrower.
+      go_version:
+        type: string
+        required: false
+        default: '1.26'
+        description: >-
+          Go toolchain version for setup-go. Defaults to '1.26'. Set to match
+          your module's go.mod (e.g. '1.26.5') when a build/release needs a
+          specific patch release.
+      goreleaser_extra_args:
+        type: string
+        required: false
+        default: ''
+        description: >-
+          Extra arguments appended to `goreleaser release --clean`, e.g.
+          `--skip=chocolatey,snapcraft` when those publishers run in a separate
+          per-repo job (they need tooling/runners this ubuntu job lacks).
+    outputs:
+      tag:
+        description: >-
+          The tag github-tag-action created this run, or empty when no tag was
+          cut (no bumping commits) or the run was already on a tag. Consumers can
+          chain per-repo publisher jobs on `needs.<job>.outputs.tag`.
+        value: ${{ jobs.release.outputs.tag }}
 #  push:
 #    tags:
 #      - 'v*.*.*'   # triggers only on tags like v1.26.0
@@ -37,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # required for GoReleaser to push GitHub releases
+    outputs:
+      tag: ${{ steps.tag.outputs.new_tag }}
 
     steps:
       # 1. Checkout the code with full history + all tags. Both GoReleaser (changelog /
@@ -48,7 +97,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26'   # adjust to your project Go version
+          go-version: ${{ inputs.go_version }}
 
       # Authenticate private-module fetches (GoReleaser's `go mod tidy` hook runs
       # BEFORE the build and will fail to reach private deps otherwise). No-op for
@@ -57,7 +106,14 @@ jobs:
         if: ${{ inputs.GOPRIVATE }}
         run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@${{ inputs.goprivate_git_host }}/".insteadOf "https://${{ inputs.goprivate_git_host }}/"
 
+      # Auto-bump only when the caller triggered on a branch push/merge. On a tag
+      # push (github.ref_type == 'tag') the version is already fixed by the tag,
+      # so skip the bump and release that exact tag as-is. This lets callers keep
+      # an explicit "push a vX.Y.Z tag to release" flow while still sharing this
+      # workflow — no auto-bump can override the tag they chose.
       - name: Bump version and push tag
+        id: tag
+        if: ${{ github.ref_type != 'tag' }}
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +125,12 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: v2
-          args: release --clean
+          args: release --clean ${{ inputs.goreleaser_extra_args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # required for releases
           GOPRIVATE: ${{ inputs.GOPRIVATE }}
+          # Optional cross-repo publisher credentials. Empty when the caller
+          # doesn't pass them; GoReleaser only reads the ones its config uses.
+          GORELEASER_GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,50 @@ discouraged for the reasons above.
 > Existing `@main` consumers are **not** being mass-migrated. Adopt `@v1` (or the
 > Renovate preset) gradually, per repo, on your own schedule.
 
+## Releasing with `release.yml`
+
+`release.yml` runs the GoReleaser flow: checkout (full history) → setup-go →
+optional auto-tag → `goreleaser release --clean` against **your repo's own**
+`.goreleaser.yaml`. Two trigger styles are supported:
+
+- **Push to `main`** — `github-tag-action` bumps from conventional commits and
+  releases the new tag (continuous delivery).
+- **Push a `vX.Y.Z` tag** — the auto-bump step is skipped (the tag already fixes
+  the version) and GoReleaser releases that exact tag. Use this for an explicit,
+  human-gated "cut a release by pushing a tag" flow.
+
+Publishers that push to **other** repos (Homebrew, Scoop, WinGet, AUR) need
+credentials the default `GITHUB_TOKEN` can't provide. Pass them as optional
+secrets; GoReleaser reads only the ones your config references:
+
+```yaml
+on:
+  push:
+    tags: ['v*']
+permissions:
+  contents: write
+jobs:
+  release:
+    uses: strongo/cicd/.github/workflows/release.yml@v1
+    with:
+      go_version: '1.26.5'                 # optional; defaults to '1.26'
+      # goreleaser_extra_args: '--skip=chocolatey,snapcraft'  # optional
+    secrets:
+      GORELEASER_GITHUB_TOKEN: ${{ secrets.MY_GORELEASER_PAT }}   # brew/scoop/winget
+      WINGET_GITHUB_TOKEN:     ${{ secrets.WINGET_GITHUB_TOKEN }}  # optional, if separate
+      AUR_SSH_PRIVATE_KEY:     ${{ secrets.AUR_SSH_PRIVATE_KEY }}  # optional
+```
+
+Reference the forwarded credentials in `.goreleaser.yaml` as
+`{{ .Env.GORELEASER_GITHUB_TOKEN }}`, `{{ .Env.WINGET_GITHUB_TOKEN }}`, and
+`{{ .Env.AUR_SSH_PRIVATE_KEY }}`.
+
+Publishers that need a **different runner or extra tooling** this ubuntu job
+lacks — Chocolatey (`choco`, Windows-only), Snapcraft (`snapcraft`), or native
+macOS signing (`xcrun`/`codesign`) — cannot run here. Keep them as a small
+per-repo job (`needs:` this one) and add `--skip=chocolatey,snapcraft` via
+`goreleaser_extra_args` so this job doesn't try to run them.
+
 ## Keep the pin fresh with Renovate
 
 Add the shared preset to a consumer repo's `renovate.json` so Renovate keeps the


### PR DESCRIPTION
## What & why

Enables consumer repos with **cross-repo package publishers** (Homebrew, Scoop, WinGet, AUR) to run their whole release through the shared `release.yml`, and makes a **"push a `vX.Y.Z` tag to release"** flow work without an auto-bump overriding the chosen version. This is the enabler for converging `specscore/specscore-cli` and `ingitdb/ingitdb-cli` onto this workflow.

## Changes (all backward-compatible & optional)

`.github/workflows/release.yml`:
- **New optional secrets**, forwarded into the GoReleaser step env (GoReleaser reads only the ones a config references):
  - `GORELEASER_GITHUB_TOKEN` — cross-repo PAT (Homebrew/Scoop/WinGet)
  - `WINGET_GITHUB_TOKEN` — optional separate WinGet PAT
  - `AUR_SSH_PRIVATE_KEY` — AUR key contents (GoReleaser accepts key contents directly)
- **New optional inputs**: `go_version` (default `'1.26'`, unchanged from the previous hardcode) and `goreleaser_extra_args` (e.g. `--skip=chocolatey,snapcraft`).
- **New job output `tag`** (github-tag-action's `new_tag`) so callers can chain per-repo publisher jobs.
- **Tag-push support**: the auto-bump step is now skipped when `github.ref_type == 'tag'`, so a tag push releases that exact tag as-is. Branch-push callers are unaffected (`ref_type == 'branch'` → still bumps).

`README.md`: documents the `release.yml` calling convention (both triggers, publisher secrets, and the off-runner-publisher pattern).

## Backward compatibility

Existing push-to-`main` consumers see **no behavior change**: new secrets/inputs are optional with matching defaults, the extra env vars are empty and ignored, and the tag-push guard only affects tag-triggered callers (which didn't exist before).

## Validation

- `actionlint .github/workflows/release.yml` → clean.
- Release workflows are **structurally validated only** — running a real release in CI is unsafe, so this was reviewed structurally and via the two consumer PRs, not executed.