### PR TITLE
feat(release): guard accidental major (v0→v1) bumps; harden CD path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,36 @@ on:
           Extra arguments appended to `goreleaser release --clean`, e.g.
           `--skip=chocolatey,snapcraft` when those publishers run in a separate
           per-repo job (they need tooling/runners this ubuntu job lacks).
+      tag_prefix:
+        type: string
+        required: false
+        default: 'v'
+        description: >-
+          Prefix for version tags, e.g. "ingitdb/v" for a subdirectory module.
+          Defaults to "v". Used when the CD bump path (branch/merge trigger)
+          computes and pushes the next tag.
+      default_bump:
+        type: string
+        required: false
+        default: 'false'
+        description: >-
+          Bump level (github-tag-action semantics) applied on a CD run when NO
+          conventional commit since the last tag implies one. Default 'false':
+          docs/chore/ci-only merges cut no tag and publish nothing (GoReleaser is
+          skipped). Set 'patch' to release on every merge to main.
+      allow_major_version_bump:
+        type: boolean
+        required: false
+        default: false
+        description: >-
+          When false (default), a CD run (branch/merge trigger) whose commits
+          would bump the MAJOR version is CAPPED to a minor bump, and a warning
+          is logged. This is the guard against an accidental v0->v1 (or vN->vN+1)
+          jump from a `feat!:` / `BREAKING CHANGE:` commit — which
+          github-tag-action treats as a major bump regardless of any
+          major_string_token sentinel. Pre-1.0, a breaking change is a minor
+          bump; this preserves that. Set true only to intend a real major
+          release (or push an explicit vX.0.0 tag, which bypasses the bump).
     outputs:
       tag:
         description: >-
@@ -111,17 +141,57 @@ jobs:
       # so skip the bump and release that exact tag as-is. This lets callers keep
       # an explicit "push a vX.Y.Z tag to release" flow while still sharing this
       # workflow — no auto-bump can override the tag they chose.
-      - name: Bump version and push tag
-        id: tag
+      #
+      # The bump is two steps: a dry run computes the version github-tag-action
+      # would choose from conventional commits, then a guard caps an accidental
+      # MAJOR bump to a minor one (unless allow_major_version_bump) and pushes the
+      # final tag itself. We push with plain git (not the action) so the guard's
+      # decision is authoritative and the tag string is unambiguous.
+      - name: Compute next version (dry run)
+        id: bump_dry
         if: ${{ github.ref_type != 'tag' }}
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          default_bump: false
+          tag_prefix: ${{ inputs.tag_prefix }}
+          default_bump: ${{ inputs.default_bump }}
+          dry_run: true
+
+      - name: Determine and push guarded tag
+        id: tag
+        if: ${{ github.ref_type != 'tag' && steps.bump_dry.outputs.new_tag != '' }}
+        env:
+          PREV: ${{ steps.bump_dry.outputs.previous_version }}
+          NEXT: ${{ steps.bump_dry.outputs.new_version }}
+          NEXT_TAG: ${{ steps.bump_dry.outputs.new_tag }}
+          PREV_TAG: ${{ steps.bump_dry.outputs.previous_tag }}
+          ALLOW_MAJOR: ${{ inputs.allow_major_version_bump }}
+          PREFIX: ${{ inputs.tag_prefix }}
+        run: |
+          set -euo pipefail
+          # previous_version / new_version are bare SemVer (no prefix).
+          prev_major="${PREV%%.*}"
+          next_major="${NEXT%%.*}"
+          tag="$NEXT_TAG"
+          if [ "$ALLOW_MAJOR" != "true" ] && [ -n "$PREV" ] && [ "$next_major" -gt "$prev_major" ]; then
+            prev_minor="$(printf '%s' "$PREV" | cut -d. -f2)"
+            capped="${prev_major}.$((prev_minor + 1)).0"
+            tag="${PREFIX}${capped}"
+            echo "::warning title=Major bump blocked::A breaking commit since ${PREV_TAG} would bump the MAJOR version (${PREV} -> ${NEXT}). Capping to ${capped} (pre-1.0 / disallowed-major semantics treat a breaking change as a minor bump). Set allow_major_version_bump: true, or push an explicit vX.0.0 tag, to intend a real major."
+          fi
+          git tag "$tag"
+          git push origin "refs/tags/$tag"
+          echo "new_tag=$tag" >> "$GITHUB_OUTPUT"
 
       - run: git fetch --tags
 
+      # Release the tag on HEAD: the exact tag on a tag-push, or the one the
+      # guarded bump just cut on a branch/merge. On a branch/merge with no
+      # bumping commit no tag was cut, so HEAD is untagged and there is nothing
+      # to release — skip GoReleaser (running it on an untagged commit would
+      # fail the job).
       - name: Run GoReleaser
+        if: ${{ github.ref_type == 'tag' || steps.tag.outputs.new_tag != '' }}
         uses: goreleaser/goreleaser-action@v7
         with:
           version: v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -284,17 +284,52 @@ jobs:
           # letting the action evaluate the whole lastTag..HEAD range. (fetch-depth: 0
           # fetches all tags too, so the previous version is always found.)
           fetch-depth: 0
+          # Persist GH_TOKEN so the guarded `git push` of the computed tag below
+          # is authenticated the same way the action's push used to be.
+          token: ${{ secrets.GH_TOKEN }}
 
+      # Bump is two steps: a dry run computes the version github-tag-action would
+      # pick from conventional commits, then a guard caps an accidental MAJOR
+      # bump to a minor (unless allow_major_version_bump) and pushes the final
+      # tag with git. This closes the hole where a `feat!:` / `BREAKING CHANGE:`
+      # commit would jump a pre-1.0 module v0 -> v1: the major_string_token
+      # sentinel only blocks the `#major` token path, NOT conventional breaking
+      # changes, which github-tag-action still bumps to a major.
       - if: ${{ github.ref == 'refs/heads/main' }}
-        id: tag_version
-        name: Bump version and push tag
+        id: bump_dry
+        name: Compute next version (dry run)
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           tag_prefix: ${{ inputs.tag_prefix }}
           default_bump: ${{ inputs.default_bump }}
           major_string_token: ${{ inputs.allow_major_version_bump && '#major' || '##no-major-bumps##' }}
-          # fetch_all_tags: true - By default, this action fetch the last 100 tags from Github.
+          dry_run: true
+
+      - if: ${{ github.ref == 'refs/heads/main' && steps.bump_dry.outputs.new_tag != '' }}
+        id: tag_version
+        name: Determine and push guarded tag
+        env:
+          PREV: ${{ steps.bump_dry.outputs.previous_version }}
+          NEXT: ${{ steps.bump_dry.outputs.new_version }}
+          NEXT_TAG: ${{ steps.bump_dry.outputs.new_tag }}
+          PREV_TAG: ${{ steps.bump_dry.outputs.previous_tag }}
+          ALLOW_MAJOR: ${{ inputs.allow_major_version_bump }}
+          PREFIX: ${{ inputs.tag_prefix }}
+        run: |
+          set -euo pipefail
+          prev_major="${PREV%%.*}"
+          next_major="${NEXT%%.*}"
+          tag="$NEXT_TAG"
+          if [ "$ALLOW_MAJOR" != "true" ] && [ -n "$PREV" ] && [ "$next_major" -gt "$prev_major" ]; then
+            prev_minor="$(printf '%s' "$PREV" | cut -d. -f2)"
+            capped="${prev_major}.$((prev_minor + 1)).0"
+            tag="${PREFIX}${capped}"
+            echo "::warning title=Major bump blocked::A breaking commit since ${PREV_TAG} would bump the MAJOR version (${PREV} -> ${NEXT}). Capping to ${capped} (pre-1.0 / disallowed-major semantics treat a breaking change as a minor bump). Set allow_major_version_bump: true to intend a real major."
+          fi
+          git tag "$tag"
+          git push origin "refs/tags/$tag"
+          echo "new_tag=$tag" >> "$GITHUB_OUTPUT"
 
 
 #  go_release:

--- a/README.md
+++ b/README.md
@@ -168,8 +168,24 @@ last tag** and pushes a new SemVer tag:
 | --- | --- |
 | `fix:` | patch bump (`v1.2.3 → v1.2.4`) |
 | `feat:` | minor bump (`v1.2.3 → v1.3.0`) |
-| `feat!:` / `BREAKING CHANGE:` | major bump — only if `allow_major_version_bump: true` |
+| `feat!:` / `BREAKING CHANGE:` | major **only if** `allow_major_version_bump: true`; otherwise **capped to a minor** bump (see guard below) |
 | docs/chore/ci/refactor only | `default_bump` decides (see below) |
+
+### Accidental-major guard (`allow_major_version_bump`)
+
+`github-tag-action` treats a `feat!:` / `BREAKING CHANGE:` commit as a **major**
+bump — and it does so **regardless** of the `major_string_token` sentinel, so
+setting that alone does **not** stop it. That is how a pre-1.0 repo silently
+jumped `v0.64.2 → v1.0.0` from a `feat(cli)!:` commit.
+
+Both the reusable `workflow.yml` (`go_bump`) and `release.yml` (CD bump path)
+now guard against this: they compute the proposed version in a **dry run**, and
+when `allow_major_version_bump` is `false` (the default) a bump that would raise
+the **major** version is **capped to a minor** bump of the previous version
+(`v0.64.2 → v0.65.0`; `v1.5.0 → v1.6.0`) with a `::warning::` in the log. Pre-1.0
+this is exactly right — a breaking change is a minor bump until you deliberately
+cut `v1.0.0`. To intend a real major, either set `allow_major_version_bump: true`
+or push an explicit `vX.0.0` tag (a tag push bypasses the bump entirely).
 
 ### Required repo settings (read this — it's why tags were being missed)
 


### PR DESCRIPTION
## Why
`github-tag-action` treats a `feat!:` / `BREAKING CHANGE:` commit as a **major** bump **regardless** of the `major_string_token` sentinel we set — so `allow_major_version_bump: false` never actually prevented a major jump. That's how **ingitdb-cli silently went `v0.64.2 → v1.0.0`** from a `feat(cli)!:` commit (and on to v1.32.0), while its releases were separately stuck at v0.40.1.

## What
Both bump paths now **dry-run** the proposed version, then **cap a disallowed major to a minor** bump and push the guarded tag with `git`:

| prev | github-tag-action wants | `allow_major=false` result |
|---|---|---|
| v0.64.2 | v1.0.0 (from `feat!:`) | **v0.65.0** + `::warning::` |
| v1.5.0 | v2.0.0 | **v1.6.0** + `::warning::` |
| v0.64.2 | v0.65.0 (`feat:`) | v0.65.0 (passthrough) |

Pre-1.0 this is exactly correct: a breaking change is a *minor* bump until you deliberately cut v1.0.0. To intend a real major: set `allow_major_version_bump: true`, or push an explicit `vX.0.0` tag (tag pushes bypass the bump).

### `release.yml` (CD path)
- New inputs: `tag_prefix`, `default_bump`, `allow_major_version_bump`.
- GoReleaser now runs **only when HEAD has a tag** (a tag-push, or a freshly-cut CD tag) — so a docs-only merge no longer fails the job by running GoReleaser on an untagged commit. This makes the `on: push: branches:[main]` continuous-delivery pattern robust.

### `workflow.yml` (`go_bump`)
- Same dry-run + cap guard, for module-only repos that tag via CI.

Tag-push releases are **unaffected** — the guard is branch-trigger only. Guard logic unit-tested locally across v0→v1, v1→v2, normal minor/patch, intended-major, and first-tag cases. `actionlint` clean (one pre-existing SC2086 on the unrelated coverage step).

Part of the ecosystem move to a single continuous-delivery release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)