### PR TITLE
fix(ci): drop dead major_string_token input from go_bump

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -303,7 +303,6 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           tag_prefix: ${{ inputs.tag_prefix }}
           default_bump: ${{ inputs.default_bump }}
-          major_string_token: ${{ inputs.allow_major_version_bump && '#major' || '##no-major-bumps##' }}
           dry_run: true
 
       - if: ${{ github.ref == 'refs/heads/main' && steps.bump_dry.outputs.new_tag != '' }}


### PR DESCRIPTION
github-tag-action@v6.2 rejects `major_string_token` as an unknown input (it was silently ignored — the root reason the old `allow_major_version_bump` gate was a no-op). The guard is now the dry-run + cap logic merged in #30; this removes the misleading dead input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)