### PR TITLE
fix: make release calculator language-neutral

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,87 @@ on:
 
 jobs:
 
+  release_calculator_regression:
+    name: Release calculator regression
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # The fixtures intentionally contain no package.json. They exercise the
+      # same pinned action and runner-local configuration as the shared release
+      # paths, including the v0 and no-release semantics that previously regressed.
+      - name: Create release-calculator fixtures
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture_root="${RUNNER_TEMP}/release-calculator-fixtures"
+          mkdir -p "$fixture_root"
+
+          make_fixture() {
+            local name="$1"
+            local message="$2"
+            local repository="$fixture_root/$name"
+            git init --initial-branch=main "$repository"
+            git -C "$repository" config user.email 'release-test@example.invalid'
+            git -C "$repository" config user.name 'Release Test'
+            git -C "$repository" commit --allow-empty -m 'chore: bootstrap'
+            git -C "$repository" tag v0.1.0
+            git -C "$repository" commit --allow-empty -m "$message"
+            test ! -e "$repository/package.json"
+          }
+
+          make_fixture v0-breaking 'feat!: change public API'
+          make_fixture docs-only 'docs(cli): explain calculation'
+
+      - name: Prepare git-cliff configuration
+        shell: bash
+        run: |
+          printf '%s\n' \
+            '[bump]' \
+            'initial_tag = "0.0.0"' \
+            'features_always_bump_minor = true' \
+            'breaking_always_bump_major = false' \
+            '[git]' \
+            'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
+            > "${RUNNER_TEMP}/cicd-git-cliff.toml"
+
+      - name: Compute a v0 breaking-change version
+        id: v0_breaking
+        uses: orhun/git-cliff-action@v4.8.0
+        with:
+          version: v2.13.1
+          config: ${{ runner.temp }}/cicd-git-cliff.toml
+          args: >-
+            --repository ${{ runner.temp }}/release-calculator-fixtures/v0-breaking
+            --bumped-version
+            --tag-pattern ^v[0-9]+\.[0-9]+\.[0-9]+$
+
+      - name: Assert v0 breaking-change behavior
+        shell: bash
+        env:
+          ACTUAL: ${{ steps.v0_breaking.outputs.content }}
+        run: test "$ACTUAL" = 'v0.2.0'
+
+      - name: Compute a documentation-only version
+        id: docs_only
+        uses: orhun/git-cliff-action@v4.8.0
+        with:
+          version: v2.13.1
+          config: ${{ runner.temp }}/cicd-git-cliff.toml
+          args: >-
+            --repository ${{ runner.temp }}/release-calculator-fixtures/docs-only
+            --bumped-version
+            --tag-pattern ^v[0-9]+\.[0-9]+\.[0-9]+$
+
+      - name: Assert documentation-only behavior
+        shell: bash
+        env:
+          ACTUAL: ${{ steps.docs_only.outputs.content }}
+        run: test "$ACTUAL" = 'v0.1.0'
+
   strongo_workflow:
 #    permissions:
 #      contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,52 +142,70 @@ jobs:
       # an explicit "push a vX.Y.Z tag to release" flow while still sharing this
       # workflow — no auto-bump can override the tag they chose.
       #
-      # The bump is two steps: a dry run computes the next version from conventional commits,
-      # then a guard caps an accidental
-      # MAJOR bump to a minor one (unless allow_major_version_bump) and pushes the
-      # final tag itself. We push with plain git (not the action) so the guard's
-      # decision is authoritative and the tag string is unambiguous.
-      - name: Compute next version (dry run)
+      # git-cliff is language-neutral: it calculates a SemVer bump from Git
+      # history and tags, without loading npm plugins or requiring package.json.
+      # It does not create a release; the guarded git-tag step below remains the
+      # sole publisher. Keep the config runner-local so consumers need no files.
+      - name: Prepare git-cliff configuration
+        if: ${{ github.ref_type != 'tag' }}
+        run: |
+          printf '%s\n' \
+            '[bump]' \
+            'initial_tag = "0.0.0"' \
+            'features_always_bump_minor = true' \
+            'breaking_always_bump_major = false' \
+            '[git]' \
+            'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
+            > "${RUNNER_TEMP}/cicd-git-cliff.toml"
+
+      # The action prints the proposed tag (with the configured prefix) to its
+      # `content` output; the resolver below converts it to bare SemVer.
+      # A breaking change under v0 is a minor bump. We push with plain git so
+      # the guard's decision is authoritative and the tag string is unambiguous.
+      - name: Compute next version from Git history
         id: bump_dry
         if: ${{ github.ref_type != 'tag' }}
-        uses: cycjimmy/semantic-release-action@v6
+        uses: orhun/git-cliff-action@v4.8.0
         with:
-          branches: main
-          dry_run: true
-          ci: false
-          tag_format: ${{ inputs.tag_prefix }}${version}
-          semantic_version: 24
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.13.1
+          config: ${{ runner.temp }}/cicd-git-cliff.toml
+          args: >-
+            --bumped-version
+            --tag-pattern ^${{ inputs.tag_prefix }}[0-9]+\.[0-9]+\.[0-9]+$
 
-      # semantic-release intentionally does not publish docs/chore-only changes.
       # Preserve default_bump for callers that explicitly request a release.
       - name: Resolve configured default bump
         id: resolved_bump
         if: ${{ github.ref == 'refs/heads/main' && github.ref_type != 'tag' }}
         env:
-          PREV: ${{ steps.bump_dry.outputs.last_release_version }}
-          NEXT: ${{ steps.bump_dry.outputs.new_release_version }}
-          NEXT_TAG: ${{ steps.bump_dry.outputs.new_release_git_tag }}
-          PREV_TAG: ${{ steps.bump_dry.outputs.last_release_git_tag }}
+          PROPOSED_VERSION: ${{ steps.bump_dry.outputs.content }}
           PREFIX: ${{ inputs.tag_prefix }}
           DEFAULT_BUMP: ${{ inputs.default_bump }}
         run: |
           set -euo pipefail
-          if [ -n "$NEXT" ]; then
-            printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s\nprevious_tag=%s\n' "$PREV" "$NEXT" "$NEXT_TAG" "$PREV_TAG" >> "$GITHUB_OUTPUT"
+          latest_tag=""
+          while IFS= read -r candidate_tag; do
+            candidate_version="${candidate_tag#"$PREFIX"}"
+            if [[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              latest_tag="$candidate_tag"
+              break
+            fi
+          done < <(git tag --list "${PREFIX}*" --sort=-v:refname)
+          previous_version="${latest_tag#"$PREFIX"}"
+          if [ -z "$latest_tag" ] || ! [[ "$previous_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            previous_version="0.0.0"
+            latest_tag=""
+          fi
+          proposed_tag="$(printf '%s' "$PROPOSED_VERSION" | tr -d '\r\n')"
+          next_version="${proposed_tag#"$PREFIX"}"
+          if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$next_version" != "$previous_version" ]; then
+            printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s%s\nprevious_tag=%s\n' "$previous_version" "$next_version" "$PREFIX" "$next_version" "$latest_tag" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$DEFAULT_BUMP" = "false" ] || [ -z "$DEFAULT_BUMP" ]; then
             exit 0
           fi
           case "$DEFAULT_BUMP" in patch|minor|major) ;; *) echo "Unsupported default_bump: $DEFAULT_BUMP" >&2; exit 1 ;; esac
-          latest_tag="$(git tag --list "${PREFIX}*" --sort=-v:refname | head -n 1)"
-          previous_version="${latest_tag#"$PREFIX"}"
-          if [ -z "$latest_tag" ] || ! [[ "$previous_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            previous_version="0.0.0"
-            latest_tag=""
-          fi
           IFS=. read -r major minor patch <<< "$previous_version"
           case "$DEFAULT_BUMP" in
             patch) next_version="$major.$minor.$((patch + 1))" ;;

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -313,55 +313,71 @@ jobs:
           # is authenticated the same way the action's push used to be.
           token: ${{ secrets.GH_TOKEN }}
 
-      # Bump is two steps: a dry run computes the next version from conventional commits,
-      # then a guard caps an accidental MAJOR
-      # bump to a minor (unless allow_major_version_bump) and pushes the final
-      # tag with git. This closes the hole where a `feat!:` / `BREAKING CHANGE:`
-      # commit would jump a pre-1.0 module v0 -> v1: the major_string_token
-      # sentinel only blocks the `#major` token path, NOT conventional breaking
-      # changes, which would otherwise bump to a major.
+      # git-cliff is language-neutral: it calculates a SemVer bump from Git
+      # history and tags, without loading npm plugins or requiring package.json.
+      # It does not create a release; the guarded git-tag step below remains the
+      # sole publisher. Keep the config runner-local so consumers need no files.
+      - if: ${{ github.ref == 'refs/heads/main' }}
+        name: Prepare git-cliff configuration
+        run: |
+          printf '%s\n' \
+            '[bump]' \
+            'initial_tag = "0.0.0"' \
+            'features_always_bump_minor = true' \
+            'breaking_always_bump_major = false' \
+            '[git]' \
+            'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
+            > "${RUNNER_TEMP}/cicd-git-cliff.toml"
+
+      # The action prints the proposed tag (with the configured prefix) to its
+      # `content` output; the resolver below converts it to bare SemVer.
+      # Full history above is required because git-cliff examines commits since
+      # the last matching tag. A breaking change under v0 is a minor bump.
       - if: ${{ github.ref == 'refs/heads/main' }}
         id: bump_dry
-        name: Compute next version (dry run)
-        uses: cycjimmy/semantic-release-action@v6
+        name: Compute next version from Git history
+        uses: orhun/git-cliff-action@v4.8.0
         with:
-          branches: main
-          dry_run: true
-          ci: false
-          tag_format: ${{ inputs.tag_prefix }}${version}
-          semantic_version: 24
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          version: v2.13.1
+          config: ${{ runner.temp }}/cicd-git-cliff.toml
+          args: >-
+            --bumped-version
+            --tag-pattern ^${{ inputs.tag_prefix }}[0-9]+\.[0-9]+\.[0-9]+$
 
-      # semantic-release intentionally does not publish docs/chore-only changes.
       # Preserve the reusable workflow's historical default_bump contract by
-      # supplying that configured bump only when semantic-release found none.
+      # applying that configured bump only when git-cliff found no semantic bump.
       - if: ${{ github.ref == 'refs/heads/main' }}
         id: resolved_bump
         name: Resolve configured default bump
         env:
-          PREV: ${{ steps.bump_dry.outputs.last_release_version }}
-          NEXT: ${{ steps.bump_dry.outputs.new_release_version }}
-          NEXT_TAG: ${{ steps.bump_dry.outputs.new_release_git_tag }}
-          PREV_TAG: ${{ steps.bump_dry.outputs.last_release_git_tag }}
+          PROPOSED_VERSION: ${{ steps.bump_dry.outputs.content }}
           PREFIX: ${{ inputs.tag_prefix }}
           DEFAULT_BUMP: ${{ inputs.default_bump }}
         run: |
           set -euo pipefail
-          if [ -n "$NEXT" ]; then
-            printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s\nprevious_tag=%s\n' "$PREV" "$NEXT" "$NEXT_TAG" "$PREV_TAG" >> "$GITHUB_OUTPUT"
+          latest_tag=""
+          while IFS= read -r candidate_tag; do
+            candidate_version="${candidate_tag#"$PREFIX"}"
+            if [[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              latest_tag="$candidate_tag"
+              break
+            fi
+          done < <(git tag --list "${PREFIX}*" --sort=-v:refname)
+          previous_version="${latest_tag#"$PREFIX"}"
+          if [ -z "$latest_tag" ] || ! [[ "$previous_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            previous_version="0.0.0"
+            latest_tag=""
+          fi
+          proposed_tag="$(printf '%s' "$PROPOSED_VERSION" | tr -d '\r\n')"
+          next_version="${proposed_tag#"$PREFIX"}"
+          if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$next_version" != "$previous_version" ]; then
+            printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s%s\nprevious_tag=%s\n' "$previous_version" "$next_version" "$PREFIX" "$next_version" "$latest_tag" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$DEFAULT_BUMP" = "false" ] || [ -z "$DEFAULT_BUMP" ]; then
             exit 0
           fi
           case "$DEFAULT_BUMP" in patch|minor|major) ;; *) echo "Unsupported default_bump: $DEFAULT_BUMP" >&2; exit 1 ;; esac
-          latest_tag="$(git tag --list "${PREFIX}*" --sort=-v:refname | head -n 1)"
-          previous_version="${latest_tag#"$PREFIX"}"
-          if [ -z "$latest_tag" ] || ! [[ "$previous_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            previous_version="0.0.0"
-            latest_tag=""
-          fi
           IFS=. read -r major minor patch <<< "$previous_version"
           case "$DEFAULT_BUMP" in
             patch) next_version="$major.$minor.$((patch + 1))" ;;

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ discouraged for the reasons above.
 optional auto-tag → `goreleaser release --clean` against **your repo's own**
 `.goreleaser.yaml`. Two trigger styles are supported:
 
-- **Push to `main`** — `github-tag-action` bumps from conventional commits and
-  releases the new tag (continuous delivery).
+- **Push to `main`** — git-cliff calculates the next version from conventional
+  commits and the shared workflow releases the new tag (continuous delivery).
 - **Push a `vX.Y.Z` tag** — the auto-bump step is skipped (the tag already fixes
   the version) and GoReleaser releases that exact tag. Use this for an explicit,
   human-gated "cut a release by pushing a tag" flow.
@@ -160,9 +160,16 @@ after the `extends`.
 
 ## Automatic version tagging
 
-On a push/merge to `main`, the `go_bump` job (workflow) / tag step (action) runs
-[`mathieudutour/github-tag-action`], which reads **conventional commits since the
-last tag** and pushes a new SemVer tag:
+On a push/merge to `main`, the `go_bump` job (workflow) / tag step (action) uses
+[git-cliff] to calculate a new SemVer version from **conventional commits since
+the last matching tag**. The shared workflow then applies its guard and pushes
+the tag with Git:
+
+We deliberately use git-cliff rather than semantic-release or an npm-oriented
+tag action. It is a language-neutral Git-history tool: callers need neither
+`package.json` nor any project-specific release metadata. It only proposes a
+version; this repository's explicit guard remains the authority that creates a
+tag, preserving our v0 policy and `default_bump` contract.
 
 | Commit type since last tag | Result |
 | --- | --- |
@@ -173,13 +180,14 @@ last tag** and pushes a new SemVer tag:
 
 ### Accidental-major guard (`allow_major_version_bump`)
 
-`github-tag-action` treats a `feat!:` / `BREAKING CHANGE:` commit as a **major**
-bump — and it does so **regardless** of the `major_string_token` sentinel, so
-setting that alone does **not** stop it. That is how a pre-1.0 repo silently
-jumped `v0.64.2 → v1.0.0` from a `feat(cli)!:` commit.
+git-cliff is configured to make a `feat!:` / `BREAKING CHANGE:` commit a
+**minor** bump while the current major is zero. The shared guard independently
+caps a proposed major bump when `allow_major_version_bump` is false. This keeps
+a pre-1.0 module on v0 unless a maintainer deliberately cuts v1.
 
-Both the reusable `workflow.yml` (`go_bump`) and `release.yml` (CD bump path)
-now guard against this: they compute the proposed version in a **dry run**, and
+The reusable `workflow.yml` (`go_bump`), `release.yml` (CD bump path), and the
+composite `action.yml` all guard against this: they compute a proposed version
+without writing a tag, and
 when `allow_major_version_bump` is `false` (the default) a bump that would raise
 the **major** version is **capped to a minor** bump of the previous version
 (`v0.64.2 → v0.65.0`; `v1.5.0 → v1.6.0`) with a `::warning::` in the log. Pre-1.0
@@ -189,7 +197,7 @@ or push an explicit `vX.0.0` tag (a tag push bypasses the bump entirely).
 
 ### Required repo settings (read this — it's why tags were being missed)
 
-`github-tag-action` derives the bump from the commit range `lastTag..HEAD`. Two
+git-cliff derives the bump from the commit range `lastTag..HEAD`. Two
 things must be true for it to see your `feat:`/`fix:` commits:
 
 1. **Full checkout.** The job checks out with **`fetch-depth: 0`** (fixed in this
@@ -249,4 +257,4 @@ We build with our own tooling:
 - **[DataTug](https://datatug.io)** — query & explore data
 <!-- /dev-approach -->
 
-[`mathieudutour/github-tag-action`]: https://github.com/mathieudutour/github-tag-action
+[`git-cliff`]: https://git-cliff.org/

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: '3m'
   github_token:
-    description: 'GitHub secret token'
+    description: 'GitHub token used to push a version tag and (when enabled) upload coverage'
     required: true
   code_coverage:
     description: set to `true` to run code coverage with Coveralls
@@ -31,6 +31,14 @@ inputs:
       push to main. IMPORTANT: for tagging to see commits that sit BEHIND a merge commit,
       the calling workflow MUST run actions/checkout with `fetch-depth: 0` (the default
       shallow clone only exposes HEADs message). See the README.
+    required: false
+    default: 'false'
+  tag_prefix:
+    description: 'Prefix for version tags, e.g. "ingitdb/v" for a subdirectory module. Defaults to "v".'
+    required: false
+    default: 'v'
+  allow_major_version_bump:
+    description: 'Allow an automatic major SemVer bump. Defaults to false so a breaking change under v0 remains a minor bump.'
     required: false
     default: 'false'
 
@@ -90,13 +98,99 @@ runs:
         # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
         # skip-build-cache: true
 
+    # git-cliff calculates versions from Git history and tags without requiring
+    # package metadata. The config is runner-local so callers need no new files.
     - if: ${{ github.ref == 'refs/heads/main' && inputs.push_tag == 'true' }}
-      name: Bump version and push tag
-      id: tag_version
-      uses: mathieudutour/github-tag-action@v6.2
+      name: Prepare git-cliff configuration
+      shell: bash
+      run: |
+        printf '%s\n' \
+          '[bump]' \
+          'initial_tag = "0.0.0"' \
+          'features_always_bump_minor = true' \
+          'breaking_always_bump_major = false' \
+          '[git]' \
+          'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
+          > "${RUNNER_TEMP}/cicd-git-cliff.toml"
+
+    - if: ${{ github.ref == 'refs/heads/main' && inputs.push_tag == 'true' }}
+      id: bump_dry
+      name: Compute next version from Git history
+      uses: orhun/git-cliff-action@v4.8.0
       with:
-        github_token: ${{ inputs.github_token }}
-        default_bump: ${{ inputs.default_bump }}
+        version: v2.13.1
+        config: ${{ runner.temp }}/cicd-git-cliff.toml
+        args: >-
+          --bumped-version
+          --tag-pattern ^${{ inputs.tag_prefix }}[0-9]+\.[0-9]+\.[0-9]+$
+
+    - if: ${{ github.ref == 'refs/heads/main' && inputs.push_tag == 'true' }}
+      id: resolved_bump
+      name: Resolve configured default bump
+      shell: bash
+      env:
+        PROPOSED_VERSION: ${{ steps.bump_dry.outputs.content }}
+        PREFIX: ${{ inputs.tag_prefix }}
+        DEFAULT_BUMP: ${{ inputs.default_bump }}
+      run: |
+        set -euo pipefail
+        latest_tag=""
+        while IFS= read -r candidate_tag; do
+          candidate_version="${candidate_tag#"$PREFIX"}"
+          if [[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            latest_tag="$candidate_tag"
+            break
+          fi
+        done < <(git tag --list "${PREFIX}*" --sort=-v:refname)
+        previous_version="${latest_tag#"$PREFIX"}"
+        if [ -z "$latest_tag" ] || ! [[ "$previous_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          previous_version="0.0.0"
+          latest_tag=""
+        fi
+        proposed_tag="$(printf '%s' "$PROPOSED_VERSION" | tr -d '\r\n')"
+        next_version="${proposed_tag#"$PREFIX"}"
+        if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$next_version" != "$previous_version" ]; then
+          printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s%s\nprevious_tag=%s\n' "$previous_version" "$next_version" "$PREFIX" "$next_version" "$latest_tag" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ "$DEFAULT_BUMP" = "false" ] || [ -z "$DEFAULT_BUMP" ]; then
+          exit 0
+        fi
+        case "$DEFAULT_BUMP" in patch|minor|major) ;; *) echo "Unsupported default_bump: $DEFAULT_BUMP" >&2; exit 1 ;; esac
+        IFS=. read -r major minor patch <<< "$previous_version"
+        case "$DEFAULT_BUMP" in
+          patch) next_version="$major.$minor.$((patch + 1))" ;;
+          minor) next_version="$major.$((minor + 1)).0" ;;
+          major) next_version="$((major + 1)).0.0" ;;
+        esac
+        printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s%s\nprevious_tag=%s\n' "$previous_version" "$next_version" "$PREFIX" "$next_version" "$latest_tag" >> "$GITHUB_OUTPUT"
+
+    - if: ${{ github.ref == 'refs/heads/main' && inputs.push_tag == 'true' && steps.resolved_bump.outputs.new_version != '' }}
+      name: Determine and push guarded tag
+      id: tag_version
+      shell: bash
+      env:
+        PREV: ${{ steps.resolved_bump.outputs.previous_version }}
+        NEXT: ${{ steps.resolved_bump.outputs.new_version }}
+        NEXT_TAG: ${{ steps.resolved_bump.outputs.new_tag }}
+        PREV_TAG: ${{ steps.resolved_bump.outputs.previous_tag }}
+        ALLOW_MAJOR: ${{ inputs.allow_major_version_bump }}
+        PREFIX: ${{ inputs.tag_prefix }}
+        PUSH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        set -euo pipefail
+        prev_major="${PREV%%.*}"
+        next_major="${NEXT%%.*}"
+        tag="$NEXT_TAG"
+        if [ "$ALLOW_MAJOR" != "true" ] && [ -n "$PREV" ] && [ "$next_major" -gt "$prev_major" ]; then
+          prev_minor="$(printf '%s' "$PREV" | cut -d. -f2)"
+          capped="${prev_major}.$((prev_minor + 1)).0"
+          tag="${PREFIX}${capped}"
+          echo "::warning title=Major bump blocked::A breaking commit since ${PREV_TAG} would bump the MAJOR version (${PREV} -> ${NEXT}). Capping to ${capped}. Set allow_major_version_bump: true to intend a real major."
+        fi
+        git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git tag "$tag"
+        git push origin "refs/tags/$tag"
 
     - if: ${{ inputs.code_coverage }}
       name: Code coverage by Coveralls


### PR DESCRIPTION
## Summary
- replace semantic-release/package.json-dependent bumping with pinned git-cliff in every shared release path
- retain the explicit guarded Git tag publisher, including v0 major-bump protection and default_bump behavior
- add a no-package-metadata regression job and document the architectural decision in the README

## Why
The previous release run failed before calculating a version because semantic-release loaded the npm plugin and required package.json. git-cliff derives versions solely from Git tags and conventional commits, so it works for Go and any other repository layout.

## Validation
- isolated git-cliff fixtures: prefixes, fix/feature, v0/v1 breaking changes, and docs/CI/chore/refactor no-release cases
- actionlint
- YAML parsing
- go test ./...