### PR TITLE
ci: make Go caches deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'src/**'
       - 'go.*'
       - '*.go'
+      - 'action.yml'
   pull_request:
     branches:
       - '**'
@@ -19,6 +20,7 @@ on:
       - 'src/**'
       - 'go.*'
       - '*.go'
+      - 'action.yml'
 
 jobs:
 
@@ -104,9 +106,29 @@ jobs:
         run: test "$ACTUAL" = 'v0.1.0'
 
   strongo_workflow:
-#    permissions:
-#      contents: write
-    uses: strongo/cicd/.github/workflows/workflow.yml@main
+    # The reusable workflow statically declares contents: write for its
+    # version-bump job, even when bumping is disabled at runtime.
+    permissions:
+      contents: write
+    uses: ./.github/workflows/workflow.yml
 
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  composite_action:
+    name: Composite action smoke test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - uses: ./
+        with:
+          github_token: ${{ github.token }}
+          push_tag: 'false'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -138,7 +138,21 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: '1.26'
-          cache-dependency-path: ${{ inputs.working_directory }}/go.sum
+          # Cache restore/save is owned explicitly below. Letting setup-go save
+          # from both parallel jobs causes a cold-cache reservation race.
+          cache: false
+
+      # Both jobs may restore the same immutable cache. Only Build & test saves
+      # a missing key, after it has successfully compiled and tested the repo.
+      # The key includes every Go input that can affect compiled artifacts.
+      - name: Restore Go dependencies and build cache
+        id: restore_go_cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-cache-${{ runner.os }}-${{ runner.arch }}-go1.26-cgo${{ inputs.cgo_enabled && '1' || '0' }}-${{ hashFiles(format('{0}/go.sum', inputs.working_directory)) }}
 
       - name: Set GitHub access token for GOPRIVATE
         if: ${{ inputs.GOPRIVATE }}
@@ -171,7 +185,10 @@ jobs:
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.
-          # skip-cache: true
+          # The action cache is intentionally disabled. Its ~120 MB restore and
+          # save frequently cost more than the analysis it avoids, and periodic
+          # invalidation creates multi-minute post-job variance.
+          skip-cache: true
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
@@ -195,7 +212,18 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: '1.26'
-          cache-dependency-path: ${{ inputs.working_directory }}/go.sum
+          # The Build & test job is the sole writer for the shared Go cache;
+          # see the matching restore in Lint above.
+          cache: false
+
+      - name: Restore Go dependencies and build cache
+        id: restore_go_cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-cache-${{ runner.os }}-${{ runner.arch }}-go1.26-cgo${{ inputs.cgo_enabled && '1' || '0' }}-${{ hashFiles(format('{0}/go.sum', inputs.working_directory)) }}
 
       - name: Set GitHub access token for GOPRIVATE
         if: ${{ inputs.GOPRIVATE }}
@@ -288,6 +316,17 @@ jobs:
           if-no-files-found: error
           compression-level: 0
           retention-days: ${{ inputs.artifact_retention_days }}
+
+      # A cache key is immutable. Saving from one deterministic job avoids the
+      # parallel setup-go cache reservation race in cold CI runs.
+      - name: Save Go dependencies and build cache
+        if: ${{ success() && steps.restore_go_cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-cache-${{ runner.os }}-${{ runner.arch }}-go1.26-cgo${{ inputs.cgo_enabled && '1' || '0' }}-${{ hashFiles(format('{0}/go.sum', inputs.working_directory)) }}
 
   go_bump:
     name: Bump version

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ discouraged for the reasons above.
 > Existing `@main` consumers are **not** being mass-migrated. Adopt `@v1` (or the
 > Renovate preset) gradually, per repo, on your own schedule.
 
+## CI cache policy
+
+The reusable Go workflow restores a single cache of Go modules and compiled Go
+packages in both parallel jobs. Only **Build & test** may save a missing cache
+key, and only after a successful build and test run. This avoids a cold-cache
+race in which both jobs attempt to reserve and upload the same key.
+
+The key is deterministic for the runner OS/architecture, Go 1.26, CGO setting,
+and the selected module's `go.sum`. The workflow intentionally disables the
+`golangci-lint-action` cache: its archive/restore overhead can exceed the lint
+analysis time and makes otherwise identical runs vary by minutes.
+
+The composite action also disables that linter cache and uses `go mod download
+all` rather than `go get ./...`, so CI never rewrites a consumer's dependency
+requirements.
+
 ## Releasing with `release.yml`
 
 `release.yml` runs the GoReleaser flow: checkout (full history) → setup-go →

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,8 @@ runs:
   using: "composite"
   steps:
 
-    - run: go get ./...
+    # CI must fetch dependencies without changing the caller's go.mod/go.sum.
+    - run: go mod download all
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
@@ -90,7 +91,10 @@ runs:
 
         # Optional: if set to true then the all caching functionality will be complete disabled,
         #           takes precedence over all other caching options.
-        # skip-cache: true
+        # A cache restore/save can cost longer than the lint analysis itself.
+        # Keep this composite action's timing stable; callers may cache Go
+        # modules/build artifacts in their enclosing workflow if needed.
+        skip-cache: true
 
         # Optional: if set to true then the action don't cache or restore ~/go/pkg.
         # skip-pkg-cache: true


### PR DESCRIPTION
Makes the shared Go CI cache behavior deterministic and validates the workflow revision itself.

- Both parallel jobs restore the same Go module/build cache; only Build & test saves a cold key.
- Disables golangci-lint-action cache, whose restore/save overhead exceeded analysis time.
- Changes the composite action from mutating `go get ./...` to read-only `go mod download all`.
- Makes provider CI call the local reusable workflow and smoke-tests the composite action.

Process: predictable CI feedback helps keep SneatBot, GameBoard, and WhatsApp changes moving on the current top priorities.

Validation: `actionlint`, YAML parsing, and `GOWORK=off go vet ./...`, `go build ./...`, `go test ./...`.