### PR TITLE
fix: preserve reusable Go cache restore key

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -326,7 +326,11 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-cache-${{ runner.os }}-${{ runner.arch }}-go1.26-cgo${{ inputs.cgo_enabled && '1' || '0' }}-${{ hashFiles(format('{0}/go.sum', inputs.working_directory)) }}
+          # Preserve the key evaluated before Go commands run. `go mod download
+          # all` may add checksums to go.sum, and recomputing hashFiles here
+          # would save a cache under a key that the next clean checkout never
+          # restores.
+          key: ${{ steps.restore_go_cache.outputs.cache-primary-key }}
 
   go_bump:
     name: Bump version

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ packages in both parallel jobs. Only **Build & test** may save a missing cache
 key, and only after a successful build and test run. This avoids a cold-cache
 race in which both jobs attempt to reserve and upload the same key.
 
-The key is deterministic for the runner OS/architecture, Go 1.26, CGO setting,
-and the selected module's `go.sum`. The workflow intentionally disables the
+The key is determined before Go commands run, from the runner OS/architecture,
+Go 1.26, CGO setting, and the selected module's `go.sum`; the matching primary
+key is also used for the sole save. The workflow intentionally disables the
 `golangci-lint-action` cache: its archive/restore overhead can exceed the lint
 analysis time and makes otherwise identical runs vary by minutes.
 


### PR DESCRIPTION
## Summary\n- save the exact key calculated by the cache restore step\n- prevent go.sum checksum additions during dependency download from creating an unreachable cache\n- document the pre-command key invariant\n\n## Validation\n- actionlint\n- GOWORK=off go mod download all\n- GOWORK=off go vet ./...\n- GOWORK=off go build ./...\n- GOWORK=off go test ./...\n\nPriority: predictable CI feedback directly shortens delivery time for SneatBot, GameBoard, and WhatsApp work.