### PR TITLE
fix: make release version calculation monotonic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,40 @@ jobs:
           make_fixture() {
             local name="$1"
             local message="$2"
+            local tag="${3-v0.1.0}"
             local repository="$fixture_root/$name"
             git init --initial-branch=main "$repository"
             git -C "$repository" config user.email 'release-test@example.invalid'
             git -C "$repository" config user.name 'Release Test'
             git -C "$repository" commit --allow-empty -m 'chore: bootstrap'
-            git -C "$repository" tag v0.1.0
+            if [ -n "$tag" ]; then
+              git -C "$repository" tag "$tag"
+            fi
             git -C "$repository" commit --allow-empty -m "$message"
             test ! -e "$repository/package.json"
           }
 
           make_fixture v0-breaking 'feat!: change public API'
           make_fixture docs-only 'docs(cli): explain calculation'
+          make_fixture prefixed-first 'fix: initial release' ''
+          make_fixture shallow-source 'fix: release after a shallow checkout'
+
+          git clone --depth 1 "file://${fixture_root}/shallow-source" "$fixture_root/shallow-clone"
+          test "$(git -C "$fixture_root/shallow-clone" rev-parse --is-shallow-repository)" = 'true'
+          test -z "$(git -C "$fixture_root/shallow-clone" tag --list 'v*')"
+
+      - name: Assert shallow callers recover complete history and tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          repository="${RUNNER_TEMP}/release-calculator-fixtures/shallow-clone"
+          if [ "$(git -C "$repository" rev-parse --is-shallow-repository)" = "true" ]; then
+            git -C "$repository" fetch --force --prune --tags --unshallow origin
+          else
+            git -C "$repository" fetch --force --prune --tags origin
+          fi
+          test "$(git -C "$repository" rev-parse --is-shallow-repository)" = 'false'
+          test "$(git -C "$repository" tag --list 'v*' --sort=-v:refname | head -n 1)" = 'v0.1.0'
 
       - name: Prepare git-cliff configuration
         shell: bash
@@ -70,6 +92,15 @@ jobs:
             '[git]' \
             'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
             > "${RUNNER_TEMP}/cicd-git-cliff.toml"
+
+          printf '%s\n' \
+            '[bump]' \
+            'initial_tag = "backend/v0.0.0"' \
+            'features_always_bump_minor = true' \
+            'breaking_always_bump_major = false' \
+            '[git]' \
+            'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
+            > "${RUNNER_TEMP}/cicd-git-cliff-prefixed.toml"
 
       - name: Compute a v0 breaking-change version
         id: v0_breaking
@@ -104,6 +135,50 @@ jobs:
         env:
           ACTUAL: ${{ steps.docs_only.outputs.content }}
         run: test "$ACTUAL" = 'v0.1.0'
+
+      - name: Compute a first prefixed version
+        id: prefixed_first
+        uses: orhun/git-cliff-action@v4.8.0
+        with:
+          version: v2.13.1
+          config: ${{ runner.temp }}/cicd-git-cliff-prefixed.toml
+          args: >-
+            --repository ${{ runner.temp }}/release-calculator-fixtures/prefixed-first
+            --bumped-version
+            --tag-pattern ^backend/v[0-9]+\.[0-9]+\.[0-9]+$
+
+      - name: Assert prefixed first-release behavior
+        shell: bash
+        env:
+          ACTUAL: ${{ steps.prefixed_first.outputs.content }}
+        run: test "$ACTUAL" = 'backend/v0.0.1'
+
+      - name: Assert version resolution is monotonic
+        shell: bash
+        run: |
+          set -euo pipefail
+          version_is_greater() {
+            local candidate="$1"
+            local baseline="$2"
+            [ "$candidate" != "$baseline" ] &&
+              [ "$(printf '%s\n%s\n' "$baseline" "$candidate" | sort -V | tail -n 1)" = "$candidate" ]
+          }
+
+          if version_is_greater '0.1.2' '0.1.3'; then
+            echo 'lower version was incorrectly accepted' >&2
+            exit 1
+          fi
+          if version_is_greater '0.1.3' '0.1.3'; then
+            echo 'equal version was incorrectly accepted' >&2
+            exit 1
+          fi
+          version_is_greater '0.1.4' '0.1.3'
+          version_is_greater '0.10.0' '0.9.9'
+
+          previous_version='0.1.3'
+          IFS=. read -r major minor patch <<< "$previous_version"
+          fallback_version="$major.$minor.$((patch + 1))"
+          test "$fallback_version" = '0.1.4'
 
   strongo_workflow:
     # The reusable workflow statically declares contents: write for its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,11 +147,13 @@ jobs:
             --bumped-version
             --tag-pattern ^backend/v[0-9]+\.[0-9]+\.[0-9]+$
 
-      - name: Assert prefixed first-release behavior
+      - name: Assert prefixed initial-version behavior
         shell: bash
         env:
           ACTUAL: ${{ steps.prefixed_first.outputs.content }}
-        run: test "$ACTUAL" = 'backend/v0.0.1'
+        # With no existing tags git-cliff returns initial_tag itself. The
+        # resolver then applies default_bump when the caller requests one.
+        run: test "$ACTUAL" = 'backend/v0.0.0'
 
       - name: Assert version resolution is monotonic
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,15 +148,18 @@ jobs:
       # sole publisher. Keep the config runner-local so consumers need no files.
       - name: Prepare git-cliff configuration
         if: ${{ github.ref_type != 'tag' }}
+        env:
+          PREFIX: ${{ inputs.tag_prefix }}
         run: |
-          printf '%s\n' \
-            '[bump]' \
-            'initial_tag = "0.0.0"' \
-            'features_always_bump_minor = true' \
-            'breaking_always_bump_major = false' \
-            '[git]' \
-            'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
-            > "${RUNNER_TEMP}/cicd-git-cliff.toml"
+          {
+            printf '%s\n' '[bump]'
+            printf 'initial_tag = "%s0.0.0"\n' "$PREFIX"
+            printf '%s\n' \
+              'features_always_bump_minor = true' \
+              'breaking_always_bump_major = false' \
+              '[git]' \
+              'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]'
+          } > "${RUNNER_TEMP}/cicd-git-cliff.toml"
 
       # The action prints the proposed tag (with the configured prefix) to its
       # `content` output; the resolver below converts it to bare SemVer.
@@ -183,6 +186,12 @@ jobs:
           DEFAULT_BUMP: ${{ inputs.default_bump }}
         run: |
           set -euo pipefail
+          version_is_greater() {
+            local candidate="$1"
+            local baseline="$2"
+            [ "$candidate" != "$baseline" ] &&
+              [ "$(printf '%s\n%s\n' "$baseline" "$candidate" | sort -V | tail -n 1)" = "$candidate" ]
+          }
           latest_tag=""
           while IFS= read -r candidate_tag; do
             candidate_version="${candidate_tag#"$PREFIX"}"
@@ -198,7 +207,7 @@ jobs:
           fi
           proposed_tag="$(printf '%s' "$PROPOSED_VERSION" | tr -d '\r\n')"
           next_version="${proposed_tag#"$PREFIX"}"
-          if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$next_version" != "$previous_version" ]; then
+          if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && version_is_greater "$next_version" "$previous_version"; then
             printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s%s\nprevious_tag=%s\n' "$previous_version" "$next_version" "$PREFIX" "$next_version" "$latest_tag" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -362,15 +362,18 @@ jobs:
       # sole publisher. Keep the config runner-local so consumers need no files.
       - if: ${{ github.ref == 'refs/heads/main' }}
         name: Prepare git-cliff configuration
+        env:
+          PREFIX: ${{ inputs.tag_prefix }}
         run: |
-          printf '%s\n' \
-            '[bump]' \
-            'initial_tag = "0.0.0"' \
-            'features_always_bump_minor = true' \
-            'breaking_always_bump_major = false' \
-            '[git]' \
-            'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
-            > "${RUNNER_TEMP}/cicd-git-cliff.toml"
+          {
+            printf '%s\n' '[bump]'
+            printf 'initial_tag = "%s0.0.0"\n' "$PREFIX"
+            printf '%s\n' \
+              'features_always_bump_minor = true' \
+              'breaking_always_bump_major = false' \
+              '[git]' \
+              'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]'
+          } > "${RUNNER_TEMP}/cicd-git-cliff.toml"
 
       # The action prints the proposed tag (with the configured prefix) to its
       # `content` output; the resolver below converts it to bare SemVer.
@@ -398,6 +401,12 @@ jobs:
           DEFAULT_BUMP: ${{ inputs.default_bump }}
         run: |
           set -euo pipefail
+          version_is_greater() {
+            local candidate="$1"
+            local baseline="$2"
+            [ "$candidate" != "$baseline" ] &&
+              [ "$(printf '%s\n%s\n' "$baseline" "$candidate" | sort -V | tail -n 1)" = "$candidate" ]
+          }
           latest_tag=""
           while IFS= read -r candidate_tag; do
             candidate_version="${candidate_tag#"$PREFIX"}"
@@ -413,7 +422,7 @@ jobs:
           fi
           proposed_tag="$(printf '%s' "$PROPOSED_VERSION" | tr -d '\r\n')"
           next_version="${proposed_tag#"$PREFIX"}"
-          if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$next_version" != "$previous_version" ]; then
+          if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && version_is_greater "$next_version" "$previous_version"; then
             printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s%s\nprevious_tag=%s\n' "$previous_version" "$next_version" "$PREFIX" "$next_version" "$latest_tag" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/README.md
+++ b/README.md
@@ -212,18 +212,20 @@ this is exactly right — a breaking change is a minor bump until you deliberate
 cut `v1.0.0`. To intend a real major, either set `allow_major_version_bump: true`
 or push an explicit `vX.0.0` tag (a tag push bypasses the bump entirely).
 
-### Required repo settings (read this — it's why tags were being missed)
+### Release-history requirements
 
 git-cliff derives the bump from the commit range `lastTag..HEAD`. Two
 things must be true for it to see your `feat:`/`fix:` commits:
 
-1. **Full checkout.** The job checks out with **`fetch-depth: 0`** (fixed in this
-   repo). With the default shallow clone the action only sees `HEAD`'s message —
+1. **Full history and tags.** The reusable workflows check out with
+   **`fetch-depth: 0`**, and the composite action now fetches complete history
+   and tags before calculating. With only the default shallow clone, git-cliff sees
+   `HEAD`'s message —
    so a `Merge pull request #N …` merge commit (which is never
    conventional-commit-shaped) produced **no bump and no tag**, even when the
    merged branch was full of `feat:`/`fix:` commits. This was the cause of
-   releases needing hand-cut tags. If you consume the **composite `action.yml`**,
-   your *own* workflow must `actions/checkout` with `fetch-depth: 0`.
+   releases needing hand-cut tags. Composite-action callers no longer need to
+   configure a special checkout depth themselves.
 
 2. **Conventional commits reach `main`.** Choose one, and set it in your repo's
    **Settings → General → Pull Requests**:

--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,7 @@ inputs:
       Bump level applied when no conventional commit since the last tag implies one.
       "false" (default) cuts a tag only when the commits since the last tag contain
       feat:/fix:/BREAKING messages; set to "patch"/"minor"/"major" to always bump on a
-      push to main. IMPORTANT: for tagging to see commits that sit BEHIND a merge commit,
-      the calling workflow MUST run actions/checkout with `fetch-depth: 0` (the default
-      shallow clone only exposes HEADs message). See the README.
+      push to main. The action fetches complete history and tags before calculating.
     required: false
     default: 'false'
   tag_prefix:
@@ -102,20 +100,37 @@ runs:
         # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
         # skip-build-cache: true
 
+    # Composite-action callers commonly use checkout's shallow default. Fetch
+    # the full history and all tags here so release correctness does not depend
+    # on every caller remembering a special checkout setting.
+    - if: ${{ github.ref == 'refs/heads/main' && inputs.push_tag == 'true' }}
+      name: Fetch complete Git history and tags
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          git fetch --force --prune --tags --unshallow origin
+        else
+          git fetch --force --prune --tags origin
+        fi
+
     # git-cliff calculates versions from Git history and tags without requiring
     # package metadata. The config is runner-local so callers need no new files.
     - if: ${{ github.ref == 'refs/heads/main' && inputs.push_tag == 'true' }}
       name: Prepare git-cliff configuration
       shell: bash
+      env:
+        PREFIX: ${{ inputs.tag_prefix }}
       run: |
-        printf '%s\n' \
-          '[bump]' \
-          'initial_tag = "0.0.0"' \
-          'features_always_bump_minor = true' \
-          'breaking_always_bump_major = false' \
-          '[git]' \
-          'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]' \
-          > "${RUNNER_TEMP}/cicd-git-cliff.toml"
+        {
+          printf '%s\n' '[bump]'
+          printf 'initial_tag = "%s0.0.0"\n' "$PREFIX"
+          printf '%s\n' \
+            'features_always_bump_minor = true' \
+            'breaking_always_bump_major = false' \
+            '[git]' \
+            'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]'
+        } > "${RUNNER_TEMP}/cicd-git-cliff.toml"
 
     - if: ${{ github.ref == 'refs/heads/main' && inputs.push_tag == 'true' }}
       id: bump_dry
@@ -138,6 +153,12 @@ runs:
         DEFAULT_BUMP: ${{ inputs.default_bump }}
       run: |
         set -euo pipefail
+        version_is_greater() {
+          local candidate="$1"
+          local baseline="$2"
+          [ "$candidate" != "$baseline" ] &&
+            [ "$(printf '%s\n%s\n' "$baseline" "$candidate" | sort -V | tail -n 1)" = "$candidate" ]
+        }
         latest_tag=""
         while IFS= read -r candidate_tag; do
           candidate_version="${candidate_tag#"$PREFIX"}"
@@ -153,7 +174,7 @@ runs:
         fi
         proposed_tag="$(printf '%s' "$PROPOSED_VERSION" | tr -d '\r\n')"
         next_version="${proposed_tag#"$PREFIX"}"
-        if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ "$next_version" != "$previous_version" ]; then
+        if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && version_is_greater "$next_version" "$previous_version"; then
           printf 'previous_version=%s\nnew_version=%s\nnew_tag=%s%s\nprevious_tag=%s\n' "$previous_version" "$next_version" "$PREFIX" "$next_version" "$latest_tag" >> "$GITHUB_OUTPUT"
           exit 0
         fi


### PR DESCRIPTION
Fixes the shared release paths so they: fetch full history and tags for composite-action callers; generate a prefix-valid git-cliff initial tag; and reject equal or lower proposed versions before applying the configured fallback bump. Adds regression cases for shallow clones, prefixed first releases, and monotonic resolution. Local validation: actionlint, YAML parsing, go test, and git diff --check.