### PR TITLE
ci: make golangci-lint cache configurable

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,6 +30,11 @@ on:
         description: 'How long to wait for lint to complete before failing'
         required: false
         default: '3m'
+      golangci_lint_cache:
+        type: boolean
+        description: 'Restore and save the golangci-lint analysis cache. Disable if cache transfer is slower than linting.'
+        required: false
+        default: true
       GOOGLE_APPLICATION_CREDENTIALS:
         type: string
         description: 'Path to Google Application Credentials file'
@@ -185,10 +190,7 @@ jobs:
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.
-          # The action cache is intentionally disabled. Its ~120 MB restore and
-          # save frequently cost more than the analysis it avoids, and periodic
-          # invalidation creates multi-minute post-job variance.
-          skip-cache: true
+          skip-cache: ${{ !inputs.golangci_lint_cache }}
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,6 +35,11 @@ on:
         description: 'Restore and save the golangci-lint analysis cache. Disable if cache transfer is slower than linting.'
         required: false
         default: true
+      golangci_lint_cache_invalidation_interval:
+        type: number
+        description: 'Days between fresh golangci-lint cache namespaces.'
+        required: false
+        default: 7
       GOOGLE_APPLICATION_CREDENTIALS:
         type: string
         description: 'Path to Google Application Credentials file'
@@ -191,6 +196,7 @@ jobs:
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.
           skip-cache: ${{ !inputs.golangci_lint_cache }}
+          cache-invalidation-interval: ${{ inputs.golangci_lint_cache_invalidation_interval }}
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true

--- a/README.md
+++ b/README.md
@@ -58,13 +58,15 @@ race in which both jobs attempt to reserve and upload the same key.
 
 The key is determined before Go commands run, from the runner OS/architecture,
 Go 1.26, CGO setting, and the selected module's `go.sum`; the matching primary
-key is also used for the sole save. The workflow intentionally disables the
-`golangci-lint-action` cache: its archive/restore overhead can exceed the lint
-analysis time and makes otherwise identical runs vary by minutes.
+key is also used for the sole save. The reusable workflow enables the separate
+`golangci-lint-action` analysis cache by default. Callers can set
+`golangci_lint_cache: false` when cache transfer is slower than linting for a
+particular repository.
 
-The composite action also disables that linter cache and uses `go mod download
-all` rather than `go get ./...`, so CI never rewrites a consumer's dependency
-requirements.
+The composite action keeps that linter cache disabled; it has a separate input
+surface and is not part of this reusable-workflow timing policy. It uses `go
+mod download all` rather than `go get ./...`, so CI never rewrites a consumer's
+dependency requirements.
 
 ## Releasing with `release.yml`
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Go 1.26, CGO setting, and the selected module's `go.sum`; the matching primary
 key is also used for the sole save. The reusable workflow enables the separate
 `golangci-lint-action` analysis cache by default. Callers can set
 `golangci_lint_cache: false` when cache transfer is slower than linting for a
-particular repository.
+particular repository. `golangci_lint_cache_invalidation_interval` controls how
+many days a lint-cache namespace remains reusable and defaults to the action's
+seven-day policy.
 
 The composite action keeps that linter cache disabled; it has a separate input
 surface and is not part of this reusable-workflow timing policy. It uses `go


### PR DESCRIPTION
## What changed

- adds a `golangci_lint_cache` reusable-workflow input, enabled by default
- lets callers disable analysis caching when transfer costs exceed lint time
- exposes the cache invalidation interval, defaulting to the action's seven-day policy
- documents the reusable workflow policy separately from the composite action

## Why

Sneat-Go's old lint cache had accumulated analysis for extensions subsequently removed from the repository. A stale-seeded cache made CI slower, but a cache populated exclusively from the decoupled repository is small and materially faster.

Process: faster CI feedback shortens delivery time for fixes to the top-priority SneatBot.

## Sneat-Go timing evidence

| Scenario | Lint job | Lint-cache details |
|---|---:|---|
| Cache disabled | 2m34s | no restore/save |
| Stale-prefix first run | 6m25s | 122 MB restore; 154s save |
| Stale exact-key warm run | 2m49s | 106 MB; 50s restore |
| Truly clean population run | 2m36s | no restore; 1.7s save |
| Clean exact-key warm run 1 | 1m32s | 1.7 MB; 2.0s restore; 11.2s lint |
| Clean exact-key warm run 2 | 1m43s | 1.7 MB; 1.6s restore; 9.9s lint |

The two clean warm runs are 51–62 seconds faster than cache-off. The clean archive is about 98.5% smaller than the stale archive.

## Validation

- `actionlint .github/workflows/workflow.yml .github/workflows/ci.yml .github/workflows/release.yml`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- shared workflow PR checks, composite-action smoke test, and release-calculator regression checks passed
- Sneat-Go clean population run plus two exact-SHA warm reruns passed

## Rollout

After release, delete only Sneat-Go's stale `golangci-lint.cache` entries, update the Sneat-Go probe to the immutable release commit, and require its normal PR/main/deployment gates.
