### PR TITLE
feat(ci): support scoped private modules from multiple owners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,14 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/workflow.yml
+    with:
+      # Exercise the scoped multi-owner path in both reusable-workflow jobs.
+      # This repository has no dependencies, so the values only validate
+      # configuration and cannot grant access to unrelated repositories.
+      GOPRIVATE: github.com/strongo,github.com/bots-go-framework
+      goprivate_git_hosts: |
+        github.com/strongo
+        github.com/bots-go-framework
 
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,17 @@ on:
         required: false
         default: 'github.com'
         description: >-
-          URL prefix (host or host/org) authenticated with GH_TOKEN when fetching
-          private Go modules. Defaults to github.com; set e.g. github.com/my-org
-          to scope the token URL-rewrite narrower.
+          Legacy single URL prefix authenticated with GH_TOKEN. Ignored when
+          goprivate_git_hosts is set. Defaults to github.com for backward
+          compatibility.
+      goprivate_git_hosts:
+        type: string
+        required: false
+        default: ''
+        description: >-
+          Comma- or newline-separated host/owner URL prefixes authenticated with
+          GH_TOKEN, e.g. github.com/my-org,github.com/another-org. Each entry must
+          include an owner; host-wide entries are rejected.
       go_version:
         type: string
         required: false
@@ -315,7 +323,33 @@ jobs:
       # repos that don't pass GOPRIVATE.
       - name: Set GitHub access token for GOPRIVATE
         if: ${{ inputs.GOPRIVATE }}
-        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@${{ inputs.goprivate_git_host }}/".insteadOf "https://${{ inputs.goprivate_git_host }}/"
+        shell: bash
+        env:
+          PRIVATE_GIT_TOKEN: ${{ secrets.GH_TOKEN }}
+          PRIVATE_GIT_HOST: ${{ inputs.goprivate_git_host }}
+          PRIVATE_GIT_HOSTS: ${{ inputs.goprivate_git_hosts }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PRIVATE_GIT_TOKEN" ]; then
+            echo "::error title=Missing private-module token::GH_TOKEN is required when GOPRIVATE is set."
+            exit 1
+          fi
+          prefixes="${PRIVATE_GIT_HOSTS:-$PRIVATE_GIT_HOST}"
+          configured=0
+          while IFS= read -r raw_prefix; do
+            prefix="$(printf '%s' "$raw_prefix" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's:/*$::')"
+            [ -z "$prefix" ] && continue
+            if [ -n "$PRIVATE_GIT_HOSTS" ] && ! [[ "$prefix" =~ ^[A-Za-z0-9.-]+/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$ ]]; then
+              echo "::error title=Invalid goprivate_git_hosts entry::'$prefix' must be a host/owner URL prefix such as github.com/my-org; host-wide credential rewrites are not allowed."
+              exit 1
+            fi
+            git config --global "url.https://${PRIVATE_GIT_TOKEN}:x-oauth-basic@${prefix}/.insteadOf" "https://${prefix}/"
+            configured=$((configured + 1))
+          done < <(printf '%s\n' "$prefixes" | tr ',' '\n')
+          if [ "$configured" -eq 0 ]; then
+            echo "::error title=Missing GOPRIVATE Git prefix::Set goprivate_git_hosts or goprivate_git_host when GOPRIVATE is set."
+            exit 1
+          fi
 
       # Auto-bump only when the caller triggered on a branch push/merge. On a tag
       # push (github.ref_type == 'tag') the version is already fixed by the tag,

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,9 +51,14 @@ on:
         default: ''
       goprivate_git_host:
         type: string
-        description: 'URL prefix (host or host/org) authenticated with GH_TOKEN when fetching private Go modules. Defaults to github.com (host-wide); set to e.g. github.com/my-org to scope narrower.'
+        description: 'Legacy single URL prefix authenticated with GH_TOKEN. Ignored when goprivate_git_hosts is set. Defaults to github.com for backward compatibility.'
         required: false
         default: 'github.com'
+      goprivate_git_hosts:
+        type: string
+        description: 'Comma- or newline-separated host/owner URL prefixes authenticated with GH_TOKEN, e.g. github.com/my-org,github.com/another-org. Each entry must include an owner; host-wide entries are rejected.'
+        required: false
+        default: ''
       additional_go_test_path:
         type: string
         required: false
@@ -166,7 +171,33 @@ jobs:
 
       - name: Set GitHub access token for GOPRIVATE
         if: ${{ inputs.GOPRIVATE }}
-        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@${{ inputs.goprivate_git_host }}/".insteadOf "https://${{ inputs.goprivate_git_host }}/"
+        shell: bash
+        env:
+          PRIVATE_GIT_TOKEN: ${{ secrets.GH_TOKEN }}
+          PRIVATE_GIT_HOST: ${{ inputs.goprivate_git_host }}
+          PRIVATE_GIT_HOSTS: ${{ inputs.goprivate_git_hosts }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PRIVATE_GIT_TOKEN" ]; then
+            echo "::error title=Missing private-module token::GH_TOKEN is required when GOPRIVATE is set."
+            exit 1
+          fi
+          prefixes="${PRIVATE_GIT_HOSTS:-$PRIVATE_GIT_HOST}"
+          configured=0
+          while IFS= read -r raw_prefix; do
+            prefix="$(printf '%s' "$raw_prefix" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's:/*$::')"
+            [ -z "$prefix" ] && continue
+            if [ -n "$PRIVATE_GIT_HOSTS" ] && ! [[ "$prefix" =~ ^[A-Za-z0-9.-]+/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$ ]]; then
+              echo "::error title=Invalid goprivate_git_hosts entry::'$prefix' must be a host/owner URL prefix such as github.com/my-org; host-wide credential rewrites are not allowed."
+              exit 1
+            fi
+            git config --global "url.https://${PRIVATE_GIT_TOKEN}:x-oauth-basic@${prefix}/.insteadOf" "https://${prefix}/"
+            configured=$((configured + 1))
+          done < <(printf '%s\n' "$prefixes" | tr ',' '\n')
+          if [ "$configured" -eq 0 ]; then
+            echo "::error title=Missing GOPRIVATE Git prefix::Set goprivate_git_hosts or goprivate_git_host when GOPRIVATE is set."
+            exit 1
+          fi
 
       - name: Download dependencies
         run: go mod download all
@@ -235,7 +266,33 @@ jobs:
 
       - name: Set GitHub access token for GOPRIVATE
         if: ${{ inputs.GOPRIVATE }}
-        run: git config --global url."https://${{ secrets.GH_TOKEN }}:x-oauth-basic@${{ inputs.goprivate_git_host }}/".insteadOf "https://${{ inputs.goprivate_git_host }}/"
+        shell: bash
+        env:
+          PRIVATE_GIT_TOKEN: ${{ secrets.GH_TOKEN }}
+          PRIVATE_GIT_HOST: ${{ inputs.goprivate_git_host }}
+          PRIVATE_GIT_HOSTS: ${{ inputs.goprivate_git_hosts }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PRIVATE_GIT_TOKEN" ]; then
+            echo "::error title=Missing private-module token::GH_TOKEN is required when GOPRIVATE is set."
+            exit 1
+          fi
+          prefixes="${PRIVATE_GIT_HOSTS:-$PRIVATE_GIT_HOST}"
+          configured=0
+          while IFS= read -r raw_prefix; do
+            prefix="$(printf '%s' "$raw_prefix" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's:/*$::')"
+            [ -z "$prefix" ] && continue
+            if [ -n "$PRIVATE_GIT_HOSTS" ] && ! [[ "$prefix" =~ ^[A-Za-z0-9.-]+/[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$ ]]; then
+              echo "::error title=Invalid goprivate_git_hosts entry::'$prefix' must be a host/owner URL prefix such as github.com/my-org; host-wide credential rewrites are not allowed."
+              exit 1
+            fi
+            git config --global "url.https://${PRIVATE_GIT_TOKEN}:x-oauth-basic@${prefix}/.insteadOf" "https://${prefix}/"
+            configured=$((configured + 1))
+          done < <(printf '%s\n' "$prefixes" | tr ',' '\n')
+          if [ "$configured" -eq 0 ]; then
+            echo "::error title=Missing GOPRIVATE Git prefix::Set goprivate_git_hosts or goprivate_git_host when GOPRIVATE is set."
+            exit 1
+          fi
 
       - name: Download dependencies
         run: go mod download all

--- a/README.md
+++ b/README.md
@@ -70,6 +70,34 @@ surface and is not part of this reusable-workflow timing policy. It uses `go
 mod download all` rather than `go get ./...`, so CI never rewrites a consumer's
 dependency requirements.
 
+## Private Go modules from multiple owners
+
+Set `GOPRIVATE` to the private module prefixes and `goprivate_git_hosts` to the
+matching Git URL prefixes that may receive `GH_TOKEN`. The latter accepts
+comma- or newline-separated `host/owner` entries:
+
+```yaml
+jobs:
+  ci:
+    uses: strongo/cicd/.github/workflows/workflow.yml@v1
+    with:
+      GOPRIVATE: github.com/sneat-co,github.com/sneat-games
+      goprivate_git_hosts: |
+        github.com/sneat-co
+        github.com/sneat-games
+    secrets:
+      GH_TOKEN: ${{ secrets.PRIVATE_MODULES_TOKEN }}
+```
+
+Each plural entry must include an owner or narrower repository path. A
+host-wide entry such as `github.com` is rejected, preventing the private-module
+token from being attached to unrelated GitHub fetches. The same inputs are
+available on `release.yml`.
+
+`goprivate_git_host` remains available for existing single-prefix callers. Its
+historical `github.com` default is preserved for backward compatibility, but
+new and migrated callers should use the scoped plural input.
+
 ## Releasing with `release.yml`
 
 `release.yml` runs the GoReleaser flow: checkout (full history) → setup-go →


### PR DESCRIPTION
## Summary

- add a scoped plural `goprivate_git_hosts` input to reusable CI and release workflows
- support private Go modules from multiple GitHub owners without host-wide credential rewrites
- preserve the legacy singular input for existing callers
- exercise the multi-owner path in this repository's own CI and document caller usage

## Safety

- plural entries must include an owner (or narrower repository path)
- host-wide entries such as `github.com` are rejected
- the token remains sourced from the existing masked `GH_TOKEN` secret

## Validation

- `actionlint`
- `go test ./...`
- `git diff --check`
- manual two-owner rewrite validation
- manual host-wide rejection validation
