### PR TITLE
fix(ci): remove the git-cliff directory this workflow leaves in callers' checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,19 @@ jobs:
             --bumped-version
             --tag-pattern ^v[0-9]+\.[0-9]+\.[0-9]+$
 
+      # git-cliff-action unpacks its binary into ./git-cliff/ inside the
+      # caller's checkout and never removes it. Any later step that inspects
+      # the worktree then sees an untracked directory: GoReleaser refuses
+      # outright with "git is in a dirty state", failing the release before it
+      # can tag anything. Three repositories hit this on the same day, each
+      # looking like a local problem. A shared workflow must not leave build
+      # artifacts in a consumer's worktree, so remove it as soon as the step
+      # that created it is done.
+      - name: Remove git-cliff working directory
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf git-cliff
+
       - name: Assert v0 breaking-change behavior
         shell: bash
         env:
@@ -130,6 +143,19 @@ jobs:
             --bumped-version
             --tag-pattern ^v[0-9]+\.[0-9]+\.[0-9]+$
 
+      # git-cliff-action unpacks its binary into ./git-cliff/ inside the
+      # caller's checkout and never removes it. Any later step that inspects
+      # the worktree then sees an untracked directory: GoReleaser refuses
+      # outright with "git is in a dirty state", failing the release before it
+      # can tag anything. Three repositories hit this on the same day, each
+      # looking like a local problem. A shared workflow must not leave build
+      # artifacts in a consumer's worktree, so remove it as soon as the step
+      # that created it is done.
+      - name: Remove git-cliff working directory
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf git-cliff
+
       - name: Assert documentation-only behavior
         shell: bash
         env:
@@ -146,6 +172,19 @@ jobs:
             --repository ${{ runner.temp }}/release-calculator-fixtures/prefixed-first
             --bumped-version
             --tag-pattern ^backend/v[0-9]+\.[0-9]+\.[0-9]+$
+
+      # git-cliff-action unpacks its binary into ./git-cliff/ inside the
+      # caller's checkout and never removes it. Any later step that inspects
+      # the worktree then sees an untracked directory: GoReleaser refuses
+      # outright with "git is in a dirty state", failing the release before it
+      # can tag anything. Three repositories hit this on the same day, each
+      # looking like a local problem. A shared workflow must not leave build
+      # artifacts in a consumer's worktree, so remove it as soon as the step
+      # that created it is done.
+      - name: Remove git-cliff working directory
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf git-cliff
 
       - name: Assert prefixed initial-version behavior
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,6 +391,19 @@ jobs:
             --bumped-version
             --tag-pattern ^${{ inputs.tag_prefix }}[0-9]+\.[0-9]+\.[0-9]+$
 
+      # git-cliff-action unpacks its binary into ./git-cliff/ inside the
+      # caller's checkout and never removes it. Any later step that inspects
+      # the worktree then sees an untracked directory: GoReleaser refuses
+      # outright with "git is in a dirty state", failing the release before it
+      # can tag anything. Three repositories hit this on the same day, each
+      # looking like a local problem. A shared workflow must not leave build
+      # artifacts in a consumer's worktree, so remove it as soon as the step
+      # that created it is done.
+      - name: Remove git-cliff working directory
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf git-cliff
+
       # Preserve default_bump for callers that explicitly request a release.
       - name: Resolve configured default bump
         id: resolved_bump

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -455,6 +455,19 @@ jobs:
             --bumped-version
             --tag-pattern ^${{ inputs.tag_prefix }}[0-9]+\.[0-9]+\.[0-9]+$
 
+      # git-cliff-action unpacks its binary into ./git-cliff/ inside the
+      # caller's checkout and never removes it. Any later step that inspects
+      # the worktree then sees an untracked directory: GoReleaser refuses
+      # outright with "git is in a dirty state", failing the release before it
+      # can tag anything. Three repositories hit this on the same day, each
+      # looking like a local problem. A shared workflow must not leave build
+      # artifacts in a consumer's worktree, so remove it as soon as the step
+      # that created it is done.
+      - name: Remove git-cliff working directory
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf git-cliff
+
       # Preserve the reusable workflow's historical default_bump contract by
       # applying that configured bump only when git-cliff found no semantic bump.
       - if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
`orhun/git-cliff-action` unpacks its binary into `./git-cliff/` inside the **caller's** checkout and never cleans up. Any later step that inspects the worktree sees an untracked directory, and GoReleaser refuses outright:

```
git is in a dirty state
Please check in your pipeline what can be changing the following files:
?? git-cliff/
```

The release fails **before it can tag anything** — no version cut, no artifacts published.

## Why this is worth fixing here rather than in each consumer

Three repositories hit it on the same day — `synchestra-servers`, `synchestra`, `synchestra-vm` — each looking like a local problem, each needing its own `.gitignore` entry to work around a defect that lives in this repo. Any consumer whose release runs the bump and GoReleaser in one job is exposed; the ones that appear healthy are the ones whose GoReleaser happens to run in a separate tag-triggered run, where the bump step is skipped.

A shared workflow should not leave build artifacts in a consumer's worktree.

## The change

The directory is removed as soon as the step that created it finishes, in all three workflows that invoke the action (`release.yml`, `workflow.yml`, `ci.yml` — five call sites). `always()` so a failing bump doesn't strand it either.

Additive only: 65 lines, no existing step altered. All three workflows verified to still parse.

## Rollout

Consumers pin a range of refs (`@main`, `@v1`, `@v1.10.5`, `@v1.11.0`, pinned SHAs), so tagging alone does not deliver this everywhere. Note that `v1` currently points at `d4e8606`, well behind `v1.12.0` — moving it forward delivers everything since, which is a separate decision from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)