### PR TITLE
feat: revalidate existing release artifacts safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,17 @@ on:
           Prefix for version tags, e.g. "ingitdb/v" for a subdirectory module.
           Defaults to "v". Used when the CD bump path (branch/merge trigger)
           computes and pushes the next tag.
+      existing_artifact_tag:
+        type: string
+        required: false
+        default: ''
+        description: >-
+          Exact existing release tag to validate without creating or publishing
+          anything. It must equal tag_prefix followed by a plain SemVer value
+          (for example, tag_prefix "v" plus "0.33.0" is "v0.33.0"). When
+          set, the release/tagging/GoReleaser path is skipped and only the
+          resolved published-archive smoke jobs run against this exact tag.
+          Leave empty for the normal release behavior.
       default_bump:
         type: string
         required: false
@@ -298,8 +309,80 @@ on:
 #      - 'v*.*.*'   # triggers only on tags like v1.26.0
 
 jobs:
+  validate_release_mode:
+    name: Validate release mode
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      existing_artifact_tag: ${{ steps.validate.outputs.existing_artifact_tag }}
+      historical_artifact_validation: ${{ steps.validate.outputs.historical_artifact_validation }}
+    steps:
+      - name: Validate existing artifact tag and release-mode inputs
+        id: validate
+        shell: bash
+        env:
+          EXISTING_ARTIFACT_TAG: ${{ inputs.existing_artifact_tag }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
+          DEFAULT_BUMP: ${{ inputs.default_bump }}
+          ALLOW_MAJOR_VERSION_BUMP: ${{ inputs.allow_major_version_bump }}
+          GORELEASER_EXTRA_ARGS: ${{ inputs.goreleaser_extra_args }}
+          ARTIFACT_SMOKE_TEST: ${{ inputs.artifact_smoke_test }}
+          ARTIFACT_SMOKE_TEST_PLATFORMS: ${{ inputs.artifact_smoke_test_platforms }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+          tag="$EXISTING_ARTIFACT_TAG"
+          if [ -z "$tag" ]; then
+            echo "historical_artifact_validation=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$tag" != "$TAG_PREFIX"* ]]; then
+            echo "::error title=Invalid existing artifact tag::'$tag' must start with tag_prefix '$TAG_PREFIX'."
+            exit 1
+          fi
+          version="${tag#"$TAG_PREFIX"}"
+          if [ -z "$version" ] || ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error title=Invalid existing artifact tag::'$tag' must equal tag_prefix '$TAG_PREFIX' followed by plain SemVer (major.minor.patch)."
+            exit 1
+          fi
+
+          # Historical validation is deliberately non-publishing. Reject inputs
+          # that request release behavior instead of silently ignoring them.
+          if [ "$GITHUB_REF_TYPE" = "tag" ] || [ "$DEFAULT_BUMP" != "false" ] || [ "$ALLOW_MAJOR_VERSION_BUMP" = "true" ] || [ -n "$GORELEASER_EXTRA_ARGS" ]; then
+            echo "::error title=Conflicting release-mode input::existing_artifact_tag cannot be combined with a tag trigger, default_bump, allow_major_version_bump, or goreleaser_extra_args. Dispatch validation from a branch with release-mode inputs at their defaults."
+            exit 1
+          fi
+          if [ "$ARTIFACT_SMOKE_TEST" != "true" ]; then
+            echo "::error title=Historical validation disabled::existing_artifact_tag requires artifact_smoke_test: true so a validation dispatch cannot pass without executing a published artifact."
+            exit 1
+          fi
+          if ! python3 - "$ARTIFACT_SMOKE_TEST_PLATFORMS" <<'PY'
+          import json
+          import sys
+
+          try:
+              platforms = json.loads(sys.argv[1])
+          except (TypeError, ValueError):
+              sys.exit(1)
+          if not isinstance(platforms, list) or not platforms:
+              sys.exit(1)
+          PY
+          then
+            echo "::error title=No historical validation platform::existing_artifact_tag requires a non-empty artifact_smoke_test_platforms JSON array so the workflow cannot pass without executing a published artifact."
+            exit 1
+          fi
+
+          {
+            echo "existing_artifact_tag=$tag"
+            echo "historical_artifact_validation=true"
+          } >> "$GITHUB_OUTPUT"
+
   release:
     name: GoReleaser
+    needs: validate_release_mode
+    if: ${{ needs.validate_release_mode.result == 'success' && inputs.existing_artifact_tag == '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write   # required for GoReleaser to push GitHub releases
@@ -519,8 +602,14 @@ jobs:
   # each repeat this checkout/parse.
   resolve_artifact_smoke_test:
     name: Resolve artifact smoke test target
-    needs: release
-    if: ${{ inputs.artifact_smoke_test && !failure() && !cancelled() && (needs.release.outputs.tag != '' || github.ref_type == 'tag') }}
+    needs: [ validate_release_mode, release ]
+    if: >-
+      ${{ always() && !cancelled() &&
+          needs.validate_release_mode.result == 'success' &&
+          inputs.artifact_smoke_test &&
+          (inputs.existing_artifact_tag != '' ||
+            (needs.release.result == 'success' &&
+              (needs.release.outputs.tag != '' || github.ref_type == 'tag'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -537,14 +626,22 @@ jobs:
       homebrew_cask_name: ${{ steps.resolve.outputs.homebrew_cask_name }}
 
     steps:
-      - name: Determine the tag this run published
+      - name: Determine the artifact tag to verify
         id: release_tag
         env:
+          EXISTING_ARTIFACT_TAG: ${{ needs.validate_release_mode.outputs.existing_artifact_tag }}
           RELEASE_TAG: ${{ needs.release.outputs.tag }}
         run: |
           set -euo pipefail
-          tag="$RELEASE_TAG"
-          [ -z "$tag" ] && tag="${GITHUB_REF_NAME}"
+          if [ -n "$EXISTING_ARTIFACT_TAG" ]; then
+            # This mode must never use the dispatch ref as a fallback: the
+            # checked-out config and downloaded archive must be for the exact
+            # historical release the caller requested.
+            tag="$EXISTING_ARTIFACT_TAG"
+          else
+            tag="$RELEASE_TAG"
+            [ -z "$tag" ] && tag="${GITHUB_REF_NAME}"
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       # Sparse, ref-pinned checkout: we only need the GoReleaser config as it
@@ -566,6 +663,7 @@ jobs:
           BINARY_OVERRIDE: ${{ inputs.artifact_smoke_test_binary }}
           TAG: ${{ steps.release_tag.outputs.tag }}
           TAG_PREFIX: ${{ inputs.tag_prefix }}
+          HISTORICAL_ARTIFACT_VALIDATION: ${{ inputs.existing_artifact_tag != '' }}
         run: |
           set -euo pipefail
           config_file=""
@@ -642,6 +740,10 @@ jobs:
           fi
 
           if [ "$binary_resolved" = "false" ]; then
+            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
+              echo "::error::$resolve_note Historical artifact validation requires a resolved executable and cannot skip this check."
+              exit 1
+            fi
             echo "::warning::$resolve_note"
           fi
 
@@ -670,13 +772,16 @@ jobs:
   # release — this workflow is consumed by repos not enumerated here,
   # including libraries and Docker-only releases with no per-arch archive,
   # and a naming/shape mismatch is not evidence the release is broken.
-  # "Could not test" always logs ::warning:: and skips (exit 0); "tested and
-  # broken" always hard-fails (exit 1), unconditionally for layer 1.
+  # During a normal release, "could not test" logs ::warning:: and skips
+  # (exit 0); "tested and broken" always hard-fails (exit 1), unconditionally
+  # for layer 1. Historical validation is an explicit request for proof, so
+  # every "could not test" path is a hard failure there too: a green run must
+  # mean the requested published executable was actually invoked.
   artifact_smoke_test:
     name: 'Smoke test published artifact (${{ matrix.goos }}/${{ matrix.goarch }})'
     needs: [ release, resolve_artifact_smoke_test ]
     if: >-
-      ${{ needs.resolve_artifact_smoke_test.result == 'success' &&
+      ${{ always() && needs.resolve_artifact_smoke_test.result == 'success' &&
           needs.resolve_artifact_smoke_test.outputs.binary_resolved != 'false' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
@@ -693,6 +798,7 @@ jobs:
       SMOKE_CMD: ${{ inputs.artifact_smoke_test_command }}
       TIMEOUT_SECONDS: ${{ inputs.artifact_smoke_test_timeout_seconds }}
       REQUIRE_NOTARIZED: ${{ inputs.require_notarized_macos }}
+      HISTORICAL_ARTIFACT_VALIDATION: ${{ inputs.existing_artifact_tag != '' }}
 
     steps:
       # Selects only real archives ("*_<goos>_<goarch>.{tar.gz,tgz,zip}"),
@@ -797,11 +903,19 @@ jobs:
           status=$?
 
           if [ -f "${RUNNER_TEMP}/.download_timed_out" ]; then
+            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
+              echo "::error::Historical artifact validation could not download ${goos}/${goarch}: 'gh release download' did not finish within 120s and was killed. The requested published artifact was not executed."
+              exit 1
+            fi
             echo "::warning::Could not test ${goos}/${goarch}: 'gh release download' did not finish within 120s and was killed (network slowness or a GitHub API issue this run). This is NOT evidence the release is broken."
             echo "asset_found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$status" -ne 0 ]; then
+            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
+              echo "::error::Historical artifact validation could not download ${goos}/${goarch}: no release asset matched '*_${goos}_${goarch}.{tar.gz,tgz,zip}' for exact tag $TAG. The requested published artifact was not executed."
+              exit 1
+            fi
             echo "::warning::Could not test ${goos}/${goarch}: no release asset matched '*_${goos}_${goarch}.{tar.gz,tgz,zip}' for tag $TAG. This is NOT evidence the release is broken -- it means this platform isn't testable by this check as configured. Common legitimate reasons: this release doesn't publish ${goos}/${goarch} at all (a library, a Docker-only release, a universal macOS binary with no arch suffix), or its archive naming differs from GoReleaser's default '<name>_<version>_<os>_<arch>' convention (e.g. a custom archives.name_template). If ${goos}/${goarch} SHOULD be testable, fix the naming; otherwise trim artifact_smoke_test_platforms, or set artifact_smoke_test: false if this repo doesn't publish a runnable CLI binary at all."
             echo "asset_found=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -819,6 +933,10 @@ jobs:
           set +e
           archive="$(find . -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.tgz' -o -name '*.zip' \) | head -n1)"
           if [ -z "$archive" ]; then
+            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
+              echo "::error::Historical artifact validation downloaded assets for ${{ matrix.goos }}/${{ matrix.goarch }} but found no recognizable archive (.tar.gz/.tgz/.zip). The requested published artifact was not executed."
+              exit 1
+            fi
             echo "::warning::Could not test ${{ matrix.goos }}/${{ matrix.goarch }}: the download matched a release asset by name but none of them was a recognizable archive (.tar.gz/.tgz/.zip) once filtered — only non-archive sidecars (checksums, signatures, SBOMs) may have matched. This is NOT evidence the release is broken."
             echo "extracted=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -830,6 +948,10 @@ jobs:
             *.tar.gz|*.tgz) tar xzf "$archive" || extract_ok=false ;;
           esac
           if [ "$extract_ok" = false ]; then
+            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
+              echo "::error::Historical artifact validation failed to extract '$archive' for ${{ matrix.goos }}/${{ matrix.goarch }}. The requested published artifact was not executed."
+              exit 1
+            fi
             echo "::warning::Could not test ${{ matrix.goos }}/${{ matrix.goarch }}: failed to extract '$archive'. This is NOT evidence the release is broken -- the archive may be malformed, or built in a way this check's extraction logic doesn't handle."
             echo "extracted=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -842,6 +964,10 @@ jobs:
             bin_path="$(find . -maxdepth 3 -type f -name "$BINARY" | head -n1)"
           fi
           if [ -z "$bin_path" ] || [ ! -f "$bin_path" ]; then
+            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
+              echo "::error::Historical artifact validation extracted '$archive' for ${{ matrix.goos }}/${{ matrix.goarch }} but found no '$BINARY' executable. The requested published artifact was not executed."
+              exit 1
+            fi
             if [ -z "$BINARY" ]; then
               echo "::warning::Could not test ${{ matrix.goos }}/${{ matrix.goarch }}: no binary name was resolved for this repo (see the 'Resolve artifact smoke test target' job above), so this check doesn't know what to look for inside '$archive'. Set artifact_smoke_test_binary explicitly."
             else
@@ -1050,8 +1176,9 @@ jobs:
     name: 'Smoke test Homebrew cask install (darwin/arm64)'
     needs: [ release, resolve_artifact_smoke_test ]
     if: >-
-      ${{ needs.resolve_artifact_smoke_test.result == 'success' &&
+      ${{ always() && needs.resolve_artifact_smoke_test.result == 'success' &&
           needs.resolve_artifact_smoke_test.outputs.binary_resolved != 'false' &&
+          inputs.existing_artifact_tag == '' &&
           inputs.artifact_smoke_test_homebrew_cask &&
           needs.resolve_artifact_smoke_test.outputs.has_homebrew_cask == 'true' }}
     runs-on: macos-latest

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -2,6 +2,7 @@ package go_ci_action
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,6 +75,275 @@ func TestReleaseWorkflowExtractsAnAbsoluteRunnableBinaryPath(t *testing.T) {
 				t.Fatalf("binary output = %q", output)
 			}
 		})
+	}
+}
+
+func TestReleaseWorkflowHistoricalArtifactModeSelectsOnlyTheExactRequestedTag(t *testing.T) {
+	validateScript := releaseWorkflowRunBlock(t, "Validate existing artifact tag and release-mode inputs")
+	resolveTagScript := releaseWorkflowRunBlock(t, "Determine the artifact tag to verify")
+
+	for _, tc := range []struct {
+		name       string
+		env        map[string]string
+		wantStatus int
+		wantTag    string
+	}{
+		{
+			name: "valid plain semver tag",
+			env: map[string]string{
+				"EXISTING_ARTIFACT_TAG":    "v0.33.0",
+				"TAG_PREFIX":               "v",
+				"DEFAULT_BUMP":             "false",
+				"ALLOW_MAJOR_VERSION_BUMP": "false",
+				"GORELEASER_EXTRA_ARGS":    "",
+				"GITHUB_REF_TYPE":          "branch",
+			},
+			wantStatus: 0,
+			wantTag:    "v0.33.0",
+		},
+		{
+			name: "scoped prefix",
+			env: map[string]string{
+				"EXISTING_ARTIFACT_TAG":    "ingitdb/v0.33.0",
+				"TAG_PREFIX":               "ingitdb/v",
+				"DEFAULT_BUMP":             "false",
+				"ALLOW_MAJOR_VERSION_BUMP": "false",
+				"GORELEASER_EXTRA_ARGS":    "",
+				"GITHUB_REF_TYPE":          "branch",
+			},
+			wantStatus: 0,
+			wantTag:    "ingitdb/v0.33.0",
+		},
+		{
+			name: "rejects invalid semver",
+			env: map[string]string{
+				"EXISTING_ARTIFACT_TAG":    "v0.33",
+				"TAG_PREFIX":               "v",
+				"DEFAULT_BUMP":             "false",
+				"ALLOW_MAJOR_VERSION_BUMP": "false",
+				"GORELEASER_EXTRA_ARGS":    "",
+				"GITHUB_REF_TYPE":          "branch",
+			},
+			wantStatus: 1,
+		},
+		{
+			name: "rejects semver component with leading zero",
+			env: map[string]string{
+				"EXISTING_ARTIFACT_TAG":    "v01.2.3",
+				"TAG_PREFIX":               "v",
+				"DEFAULT_BUMP":             "false",
+				"ALLOW_MAJOR_VERSION_BUMP": "false",
+				"GORELEASER_EXTRA_ARGS":    "",
+				"GITHUB_REF_TYPE":          "branch",
+			},
+			wantStatus: 1,
+		},
+		{
+			name: "rejects release mode conflict",
+			env: map[string]string{
+				"EXISTING_ARTIFACT_TAG":    "v0.33.0",
+				"TAG_PREFIX":               "v",
+				"DEFAULT_BUMP":             "patch",
+				"ALLOW_MAJOR_VERSION_BUMP": "false",
+				"GORELEASER_EXTRA_ARGS":    "",
+				"GITHUB_REF_TYPE":          "branch",
+			},
+			wantStatus: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			outputFile := filepath.Join(t.TempDir(), "github-output")
+			env := maps.Clone(tc.env)
+			env["GITHUB_OUTPUT"] = outputFile
+			env["ARTIFACT_SMOKE_TEST"] = "true"
+			env["ARTIFACT_SMOKE_TEST_PLATFORMS"] = `[{"runner":"ubuntu-latest","goos":"linux","goarch":"amd64"}]`
+			output, err := runBash(t.TempDir(), validateScript, env)
+			if tc.wantStatus == 0 {
+				if err != nil {
+					t.Fatalf("validate historical mode: %v\n%s", err, output)
+				}
+				if got := githubOutput(t, outputFile, "existing_artifact_tag"); got != tc.wantTag {
+					t.Fatalf("validated tag = %q, want %q", got, tc.wantTag)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("invalid historical mode succeeded:\n%s", output)
+			}
+		})
+	}
+
+	outputFile := filepath.Join(t.TempDir(), "github-output")
+	output, err := runBash(t.TempDir(), resolveTagScript, map[string]string{
+		"EXISTING_ARTIFACT_TAG": "v0.33.0",
+		"RELEASE_TAG":           "v99.99.99",
+		"GITHUB_REF_NAME":       "main",
+		"GITHUB_OUTPUT":         outputFile,
+	})
+	if err != nil {
+		t.Fatalf("resolve exact historical tag: %v\n%s", err, output)
+	}
+	if got := githubOutput(t, outputFile, "tag"); got != "v0.33.0" {
+		t.Fatalf("resolver fell back from requested historical tag: got %q, want %q", got, "v0.33.0")
+	}
+}
+
+func TestReleaseWorkflowHistoricalArtifactCannotPassWithoutExecutingAnArtifact(t *testing.T) {
+	downloadScript := localWorkflowScript(releaseWorkflowRunBlock(t, "Download published release asset"))
+	extractScript := localWorkflowScript(releaseWorkflowRunBlock(t, "Extract published archive"))
+
+	t.Run("missing GitHub release or archive", func(t *testing.T) {
+		workspace := t.TempDir()
+		fakeBin := filepath.Join(workspace, "fake-bin")
+		if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeExecutable(t, filepath.Join(fakeBin, "gh"), "#!/usr/bin/env bash\nexit 1\n")
+
+		baseEnv := map[string]string{
+			"PATH":              fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+			"RUNNER_TEMP":       workspace,
+			"GITHUB_REPOSITORY": "specscore/specscore-cli",
+			"TAG":               "v0.33.0",
+		}
+		assertHistoricalFailureAndNormalSkip(t, workspace, downloadScript, baseEnv, "asset_found")
+	})
+
+	for _, tc := range []struct {
+		name    string
+		prepare func(*testing.T, string)
+	}{
+		{
+			name: "downloaded set has no recognized archive",
+			prepare: func(t *testing.T, workspace string) {
+				if err := os.WriteFile(filepath.Join(workspace, "checksums.txt"), []byte("sidecar"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "archive extraction fails",
+			prepare: func(t *testing.T, workspace string) {
+				if err := os.WriteFile(filepath.Join(workspace, "specscore_linux_amd64.tar.gz"), []byte("not an archive"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "archive has no resolved binary",
+			prepare: func(t *testing.T, workspace string) {
+				readme := filepath.Join(workspace, "README.md")
+				if err := os.WriteFile(readme, []byte("no executable here"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				archive := exec.Command("tar", "-C", workspace, "-czf", filepath.Join(workspace, "specscore_linux_amd64.tar.gz"), "README.md")
+				if output, err := archive.CombinedOutput(); err != nil {
+					t.Fatalf("create archive without binary: %v\n%s", err, output)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			tc.prepare(t, workspace)
+			assertHistoricalFailureAndNormalSkip(t, workspace, extractScript, map[string]string{
+				"BINARY": "specscore",
+			}, "extracted")
+		})
+	}
+}
+
+func TestReleaseWorkflowSuccessfulHistoricalValidationInvokesExecutable(t *testing.T) {
+	workspace := t.TempDir()
+	payloadDir := filepath.Join(workspace, "payload")
+	if err := os.MkdirAll(payloadDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	invokedFile := filepath.Join(workspace, "invoked")
+	writeExecutable(t, filepath.Join(payloadDir, "specscore"), "#!/usr/bin/env bash\nprintf invoked > \"$INVOKED_FILE\"\nprintf '0.33.0\\n'\n")
+	archivePath := filepath.Join(workspace, "specscore_linux_amd64.tar.gz")
+	archive := exec.Command("tar", "-C", payloadDir, "-czf", archivePath, "specscore")
+	if output, err := archive.CombinedOutput(); err != nil {
+		t.Fatalf("create valid archive: %v\n%s", err, output)
+	}
+
+	extractOutput := filepath.Join(workspace, "extract-output")
+	extractScript := localWorkflowScript(releaseWorkflowRunBlock(t, "Extract published archive"))
+	if output, err := runBash(workspace, extractScript, map[string]string{
+		"BINARY":                         "specscore",
+		"GITHUB_OUTPUT":                  extractOutput,
+		"HISTORICAL_ARTIFACT_VALIDATION": "true",
+	}); err != nil {
+		t.Fatalf("extract valid historical artifact: %v\n%s", err, output)
+	}
+
+	runScript := localWorkflowScript(releaseWorkflowRunBlock(t, "'Layer 1: run the published binary (must exit within timeout)'"))
+	output, err := runBash(workspace, runScript, map[string]string{
+		"BIN_PATH":        githubOutput(t, extractOutput, "bin_path"),
+		"SMOKE_CMD":       "--version",
+		"TIMEOUT_SECONDS": "2",
+		"INVOKED_FILE":    invokedFile,
+	})
+	if err != nil {
+		t.Fatalf("run valid historical artifact: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(invokedFile); err != nil {
+		t.Fatalf("successful historical validation did not invoke the executable: %v\n%s", err, output)
+	}
+}
+
+func assertHistoricalFailureAndNormalSkip(t *testing.T, workspace, script string, baseEnv map[string]string, outputKey string) {
+	t.Helper()
+	for _, tc := range []struct {
+		name       string
+		historical string
+		wantError  bool
+	}{
+		{name: "historical mode fails", historical: "true", wantError: true},
+		{name: "normal release mode keeps warning skip", historical: "false", wantError: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			outputFile := filepath.Join(workspace, strings.ReplaceAll(tc.name, " ", "-")+"-output")
+			env := maps.Clone(baseEnv)
+			env["GITHUB_OUTPUT"] = outputFile
+			env["HISTORICAL_ARTIFACT_VALIDATION"] = tc.historical
+			output, err := runBash(workspace, script, env)
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("historical could-not-test path passed:\n%s", output)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normal release could-not-test path no longer soft-skips: %v\n%s", err, output)
+			}
+			if got := githubOutput(t, outputFile, outputKey); got != "false" {
+				t.Fatalf("normal release %s = %q, want false", outputKey, got)
+			}
+		})
+	}
+}
+
+func localWorkflowScript(script string) string {
+	replacer := strings.NewReplacer(
+		"${{ matrix.goos }}", "linux",
+		"${{ matrix.goarch }}", "amd64",
+	)
+	return replacer.Replace(script)
+}
+
+func TestReleaseWorkflowHistoricalArtifactModeSkipsPublishingAndHomebrew(t *testing.T) {
+	workflow := readReleaseWorkflow(t)
+	for _, want := range []string{
+		"if: ${{ needs.validate_release_mode.result == 'success' && inputs.existing_artifact_tag == '' }}",
+		"${{ always() && !cancelled() &&",
+		"inputs.existing_artifact_tag != '' ||",
+		"inputs.existing_artifact_tag == '' &&",
+		"ref: ${{ steps.release_tag.outputs.tag }}",
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Fatalf("workflow does not preserve historical artifact safety contract %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changed

Adds a non-publishing existing_artifact_tag mode to the reusable release workflow.

- Validates an exact tag_prefix plus plain SemVer tag
- Skips tag creation and GoReleaser
- Resolves configuration and downloads assets from that exact tag
- Runs only raw published-archive smoke checks
- Rejects tag-trigger and release-mode conflicts
- Excludes Homebrew-cask validation from historical validation mode

## Why

A published artifact needs revalidation after a shared CI repair without creating a new release or falling back to the caller branch.

## Validation

- actionlint -color
- go test ./...
- wb --non-interactive check . --profile full

Dependency: merge this before the SpecScore CLI caller PR.