### PR TITLE
fix(ci): separate read-only artifact validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,17 +118,6 @@ on:
           Prefix for version tags, e.g. "ingitdb/v" for a subdirectory module.
           Defaults to "v". Used when the CD bump path (branch/merge trigger)
           computes and pushes the next tag.
-      existing_artifact_tag:
-        type: string
-        required: false
-        default: ''
-        description: >-
-          Exact existing release tag to validate without creating or publishing
-          anything. It must equal tag_prefix followed by a plain SemVer value
-          (for example, tag_prefix "v" plus "0.33.0" is "v0.33.0"). When
-          set, the release/tagging/GoReleaser path is skipped and only the
-          resolved published-archive smoke jobs run against this exact tag.
-          Leave empty for the normal release behavior.
       default_bump:
         type: string
         required: false
@@ -309,80 +298,8 @@ on:
 #      - 'v*.*.*'   # triggers only on tags like v1.26.0
 
 jobs:
-  validate_release_mode:
-    name: Validate release mode
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      existing_artifact_tag: ${{ steps.validate.outputs.existing_artifact_tag }}
-      historical_artifact_validation: ${{ steps.validate.outputs.historical_artifact_validation }}
-    steps:
-      - name: Validate existing artifact tag and release-mode inputs
-        id: validate
-        shell: bash
-        env:
-          EXISTING_ARTIFACT_TAG: ${{ inputs.existing_artifact_tag }}
-          TAG_PREFIX: ${{ inputs.tag_prefix }}
-          DEFAULT_BUMP: ${{ inputs.default_bump }}
-          ALLOW_MAJOR_VERSION_BUMP: ${{ inputs.allow_major_version_bump }}
-          GORELEASER_EXTRA_ARGS: ${{ inputs.goreleaser_extra_args }}
-          ARTIFACT_SMOKE_TEST: ${{ inputs.artifact_smoke_test }}
-          ARTIFACT_SMOKE_TEST_PLATFORMS: ${{ inputs.artifact_smoke_test_platforms }}
-          GITHUB_REF_TYPE: ${{ github.ref_type }}
-        run: |
-          set -euo pipefail
-          tag="$EXISTING_ARTIFACT_TAG"
-          if [ -z "$tag" ]; then
-            echo "historical_artifact_validation=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "$tag" != "$TAG_PREFIX"* ]]; then
-            echo "::error title=Invalid existing artifact tag::'$tag' must start with tag_prefix '$TAG_PREFIX'."
-            exit 1
-          fi
-          version="${tag#"$TAG_PREFIX"}"
-          if [ -z "$version" ] || ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo "::error title=Invalid existing artifact tag::'$tag' must equal tag_prefix '$TAG_PREFIX' followed by plain SemVer (major.minor.patch)."
-            exit 1
-          fi
-
-          # Historical validation is deliberately non-publishing. Reject inputs
-          # that request release behavior instead of silently ignoring them.
-          if [ "$GITHUB_REF_TYPE" = "tag" ] || [ "$DEFAULT_BUMP" != "false" ] || [ "$ALLOW_MAJOR_VERSION_BUMP" = "true" ] || [ -n "$GORELEASER_EXTRA_ARGS" ]; then
-            echo "::error title=Conflicting release-mode input::existing_artifact_tag cannot be combined with a tag trigger, default_bump, allow_major_version_bump, or goreleaser_extra_args. Dispatch validation from a branch with release-mode inputs at their defaults."
-            exit 1
-          fi
-          if [ "$ARTIFACT_SMOKE_TEST" != "true" ]; then
-            echo "::error title=Historical validation disabled::existing_artifact_tag requires artifact_smoke_test: true so a validation dispatch cannot pass without executing a published artifact."
-            exit 1
-          fi
-          if ! python3 - "$ARTIFACT_SMOKE_TEST_PLATFORMS" <<'PY'
-          import json
-          import sys
-
-          try:
-              platforms = json.loads(sys.argv[1])
-          except (TypeError, ValueError):
-              sys.exit(1)
-          if not isinstance(platforms, list) or not platforms:
-              sys.exit(1)
-          PY
-          then
-            echo "::error title=No historical validation platform::existing_artifact_tag requires a non-empty artifact_smoke_test_platforms JSON array so the workflow cannot pass without executing a published artifact."
-            exit 1
-          fi
-
-          {
-            echo "existing_artifact_tag=$tag"
-            echo "historical_artifact_validation=true"
-          } >> "$GITHUB_OUTPUT"
-
   release:
     name: GoReleaser
-    needs: validate_release_mode
-    if: ${{ needs.validate_release_mode.result == 'success' && inputs.existing_artifact_tag == '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write   # required for GoReleaser to push GitHub releases
@@ -602,14 +519,8 @@ jobs:
   # each repeat this checkout/parse.
   resolve_artifact_smoke_test:
     name: Resolve artifact smoke test target
-    needs: [ validate_release_mode, release ]
-    if: >-
-      ${{ always() && !cancelled() &&
-          needs.validate_release_mode.result == 'success' &&
-          inputs.artifact_smoke_test &&
-          (inputs.existing_artifact_tag != '' ||
-            (needs.release.result == 'success' &&
-              (needs.release.outputs.tag != '' || github.ref_type == 'tag'))) }}
+    needs: release
+    if: ${{ inputs.artifact_smoke_test && !failure() && !cancelled() && (needs.release.outputs.tag != '' || github.ref_type == 'tag') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -626,22 +537,14 @@ jobs:
       homebrew_cask_name: ${{ steps.resolve.outputs.homebrew_cask_name }}
 
     steps:
-      - name: Determine the artifact tag to verify
+      - name: Determine the tag this run published
         id: release_tag
         env:
-          EXISTING_ARTIFACT_TAG: ${{ needs.validate_release_mode.outputs.existing_artifact_tag }}
           RELEASE_TAG: ${{ needs.release.outputs.tag }}
         run: |
           set -euo pipefail
-          if [ -n "$EXISTING_ARTIFACT_TAG" ]; then
-            # This mode must never use the dispatch ref as a fallback: the
-            # checked-out config and downloaded archive must be for the exact
-            # historical release the caller requested.
-            tag="$EXISTING_ARTIFACT_TAG"
-          else
-            tag="$RELEASE_TAG"
-            [ -z "$tag" ] && tag="${GITHUB_REF_NAME}"
-          fi
+          tag="$RELEASE_TAG"
+          [ -z "$tag" ] && tag="${GITHUB_REF_NAME}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       # Sparse, ref-pinned checkout: we only need the GoReleaser config as it
@@ -663,7 +566,6 @@ jobs:
           BINARY_OVERRIDE: ${{ inputs.artifact_smoke_test_binary }}
           TAG: ${{ steps.release_tag.outputs.tag }}
           TAG_PREFIX: ${{ inputs.tag_prefix }}
-          HISTORICAL_ARTIFACT_VALIDATION: ${{ inputs.existing_artifact_tag != '' }}
         run: |
           set -euo pipefail
           config_file=""
@@ -740,10 +642,6 @@ jobs:
           fi
 
           if [ "$binary_resolved" = "false" ]; then
-            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
-              echo "::error::$resolve_note Historical artifact validation requires a resolved executable and cannot skip this check."
-              exit 1
-            fi
             echo "::warning::$resolve_note"
           fi
 
@@ -772,16 +670,13 @@ jobs:
   # release — this workflow is consumed by repos not enumerated here,
   # including libraries and Docker-only releases with no per-arch archive,
   # and a naming/shape mismatch is not evidence the release is broken.
-  # During a normal release, "could not test" logs ::warning:: and skips
-  # (exit 0); "tested and broken" always hard-fails (exit 1), unconditionally
-  # for layer 1. Historical validation is an explicit request for proof, so
-  # every "could not test" path is a hard failure there too: a green run must
-  # mean the requested published executable was actually invoked.
+  # "Could not test" always logs ::warning:: and skips (exit 0); "tested and
+  # broken" always hard-fails (exit 1), unconditionally for layer 1.
   artifact_smoke_test:
     name: 'Smoke test published artifact (${{ matrix.goos }}/${{ matrix.goarch }})'
     needs: [ release, resolve_artifact_smoke_test ]
     if: >-
-      ${{ always() && needs.resolve_artifact_smoke_test.result == 'success' &&
+      ${{ needs.resolve_artifact_smoke_test.result == 'success' &&
           needs.resolve_artifact_smoke_test.outputs.binary_resolved != 'false' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
@@ -798,7 +693,6 @@ jobs:
       SMOKE_CMD: ${{ inputs.artifact_smoke_test_command }}
       TIMEOUT_SECONDS: ${{ inputs.artifact_smoke_test_timeout_seconds }}
       REQUIRE_NOTARIZED: ${{ inputs.require_notarized_macos }}
-      HISTORICAL_ARTIFACT_VALIDATION: ${{ inputs.existing_artifact_tag != '' }}
 
     steps:
       # Selects only real archives ("*_<goos>_<goarch>.{tar.gz,tgz,zip}"),
@@ -903,19 +797,11 @@ jobs:
           status=$?
 
           if [ -f "${RUNNER_TEMP}/.download_timed_out" ]; then
-            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
-              echo "::error::Historical artifact validation could not download ${goos}/${goarch}: 'gh release download' did not finish within 120s and was killed. The requested published artifact was not executed."
-              exit 1
-            fi
             echo "::warning::Could not test ${goos}/${goarch}: 'gh release download' did not finish within 120s and was killed (network slowness or a GitHub API issue this run). This is NOT evidence the release is broken."
             echo "asset_found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ "$status" -ne 0 ]; then
-            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
-              echo "::error::Historical artifact validation could not download ${goos}/${goarch}: no release asset matched '*_${goos}_${goarch}.{tar.gz,tgz,zip}' for exact tag $TAG. The requested published artifact was not executed."
-              exit 1
-            fi
             echo "::warning::Could not test ${goos}/${goarch}: no release asset matched '*_${goos}_${goarch}.{tar.gz,tgz,zip}' for tag $TAG. This is NOT evidence the release is broken -- it means this platform isn't testable by this check as configured. Common legitimate reasons: this release doesn't publish ${goos}/${goarch} at all (a library, a Docker-only release, a universal macOS binary with no arch suffix), or its archive naming differs from GoReleaser's default '<name>_<version>_<os>_<arch>' convention (e.g. a custom archives.name_template). If ${goos}/${goarch} SHOULD be testable, fix the naming; otherwise trim artifact_smoke_test_platforms, or set artifact_smoke_test: false if this repo doesn't publish a runnable CLI binary at all."
             echo "asset_found=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -933,10 +819,6 @@ jobs:
           set +e
           archive="$(find . -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.tgz' -o -name '*.zip' \) | head -n1)"
           if [ -z "$archive" ]; then
-            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
-              echo "::error::Historical artifact validation downloaded assets for ${{ matrix.goos }}/${{ matrix.goarch }} but found no recognizable archive (.tar.gz/.tgz/.zip). The requested published artifact was not executed."
-              exit 1
-            fi
             echo "::warning::Could not test ${{ matrix.goos }}/${{ matrix.goarch }}: the download matched a release asset by name but none of them was a recognizable archive (.tar.gz/.tgz/.zip) once filtered — only non-archive sidecars (checksums, signatures, SBOMs) may have matched. This is NOT evidence the release is broken."
             echo "extracted=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -948,10 +830,6 @@ jobs:
             *.tar.gz|*.tgz) tar xzf "$archive" || extract_ok=false ;;
           esac
           if [ "$extract_ok" = false ]; then
-            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
-              echo "::error::Historical artifact validation failed to extract '$archive' for ${{ matrix.goos }}/${{ matrix.goarch }}. The requested published artifact was not executed."
-              exit 1
-            fi
             echo "::warning::Could not test ${{ matrix.goos }}/${{ matrix.goarch }}: failed to extract '$archive'. This is NOT evidence the release is broken -- the archive may be malformed, or built in a way this check's extraction logic doesn't handle."
             echo "extracted=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -964,10 +842,6 @@ jobs:
             bin_path="$(find . -maxdepth 3 -type f -name "$BINARY" | head -n1)"
           fi
           if [ -z "$bin_path" ] || [ ! -f "$bin_path" ]; then
-            if [ "$HISTORICAL_ARTIFACT_VALIDATION" = "true" ]; then
-              echo "::error::Historical artifact validation extracted '$archive' for ${{ matrix.goos }}/${{ matrix.goarch }} but found no '$BINARY' executable. The requested published artifact was not executed."
-              exit 1
-            fi
             if [ -z "$BINARY" ]; then
               echo "::warning::Could not test ${{ matrix.goos }}/${{ matrix.goarch }}: no binary name was resolved for this repo (see the 'Resolve artifact smoke test target' job above), so this check doesn't know what to look for inside '$archive'. Set artifact_smoke_test_binary explicitly."
             else
@@ -1176,9 +1050,8 @@ jobs:
     name: 'Smoke test Homebrew cask install (darwin/arm64)'
     needs: [ release, resolve_artifact_smoke_test ]
     if: >-
-      ${{ always() && needs.resolve_artifact_smoke_test.result == 'success' &&
+      ${{ needs.resolve_artifact_smoke_test.result == 'success' &&
           needs.resolve_artifact_smoke_test.outputs.binary_resolved != 'false' &&
-          inputs.existing_artifact_tag == '' &&
           inputs.artifact_smoke_test_homebrew_cask &&
           needs.resolve_artifact_smoke_test.outputs.has_homebrew_cask == 'true' }}
     runs-on: macos-latest

--- a/.github/workflows/validate-published-artifact.yml
+++ b/.github/workflows/validate-published-artifact.yml
@@ -1,0 +1,278 @@
+name: Validate published artifact
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        type: string
+        required: true
+        description: >-
+          Exact existing release tag to validate. It must equal tag_prefix
+          followed by plain SemVer and is never replaced with the caller ref.
+      tag_prefix:
+        type: string
+        required: false
+        default: 'v'
+        description: Literal prefix before the release tag's SemVer value.
+      artifact_binary:
+        type: string
+        required: true
+        description: Exact executable filename expected inside each archive.
+      artifact_command:
+        type: string
+        required: false
+        default: '--version'
+        description: Arguments passed to the published executable.
+      artifact_timeout_seconds:
+        type: number
+        required: false
+        default: 30
+        description: Maximum seconds the published executable may run.
+      artifact_platforms:
+        type: string
+        required: false
+        default: >-
+          [{"runner":"ubuntu-latest","goos":"linux","goarch":"amd64"},{"runner":"macos-latest","goos":"darwin","goarch":"arm64"}]
+        description: JSON array of runner, goos, and goarch objects to validate.
+      require_notarized_macos:
+        type: boolean
+        required: false
+        default: false
+        description: Hard-fail macOS signing and notarization findings when true.
+
+# This reusable workflow is deliberately separate from release.yml. GitHub
+# validates a called workflow's maximum permissions before evaluating job
+# conditions, so a read-only caller cannot call a workflow containing even a
+# skipped contents:write release job. Every job here is read-only by contract.
+permissions:
+  contents: read
+
+jobs:
+  validate_inputs:
+    name: Validate historical artifact request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      release_tag: ${{ steps.validate.outputs.release_tag }}
+    steps:
+      - name: Validate exact release tag and platforms
+        id: validate
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
+          ARTIFACT_BINARY: ${{ inputs.artifact_binary }}
+          ARTIFACT_PLATFORMS: ${{ inputs.artifact_platforms }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" != "$TAG_PREFIX"* ]]; then
+            echo "::error title=Invalid release tag::'$RELEASE_TAG' must start with tag_prefix '$TAG_PREFIX'."
+            exit 1
+          fi
+          version="${RELEASE_TAG#"$TAG_PREFIX"}"
+          if [ -z "$version" ] || ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error title=Invalid release tag::'$RELEASE_TAG' must equal tag_prefix '$TAG_PREFIX' followed by plain SemVer (major.minor.patch without leading zeroes)."
+            exit 1
+          fi
+          if [ -z "$ARTIFACT_BINARY" ] || ! [[ "$ARTIFACT_BINARY" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "::error title=Invalid artifact binary::artifact_binary must be one executable filename, not a path."
+            exit 1
+          fi
+          if ! python3 - "$ARTIFACT_PLATFORMS" <<'PY'
+          import json
+          import sys
+
+          try:
+              platforms = json.loads(sys.argv[1])
+          except (TypeError, ValueError):
+              sys.exit(1)
+          if not isinstance(platforms, list) or not platforms:
+              sys.exit(1)
+          required = {"runner", "goos", "goarch"}
+          if any(not isinstance(item, dict) or not required.issubset(item) for item in platforms):
+              sys.exit(1)
+          if any(not all(isinstance(item[key], str) and item[key] for key in required) for item in platforms):
+              sys.exit(1)
+          PY
+          then
+            echo "::error title=Invalid artifact platforms::artifact_platforms must be a non-empty JSON array of non-empty runner, goos, and goarch strings."
+            exit 1
+          fi
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+  validate_artifact:
+    name: 'Validate published artifact (${{ matrix.goos }}/${{ matrix.goarch }})'
+    needs: validate_inputs
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(inputs.artifact_platforms) }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.validate_inputs.outputs.release_tag }}
+      ARTIFACT_BINARY: ${{ inputs.artifact_binary }}
+      ARTIFACT_COMMAND: ${{ inputs.artifact_command }}
+      ARTIFACT_TIMEOUT_SECONDS: ${{ inputs.artifact_timeout_seconds }}
+      REQUIRE_NOTARIZED: ${{ inputs.require_notarized_macos }}
+    steps:
+      - name: Prepare bounded process runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          runner="${RUNNER_TEMP}/cicd-run-with-timeout.py"
+          printf '%s\n' \
+            'import os' \
+            'from pathlib import Path' \
+            'import signal' \
+            'import subprocess' \
+            'import sys' \
+            'import time' \
+            'timeout = float(sys.argv[1])' \
+            'marker = Path(sys.argv[2])' \
+            'command = sys.argv[3:]' \
+            'process = subprocess.Popen(command, start_new_session=True)' \
+            'try:' \
+            '    status = process.wait(timeout=timeout)' \
+            'except subprocess.TimeoutExpired:' \
+            '    marker.touch()' \
+            '    os.killpg(process.pid, signal.SIGTERM)' \
+            '    try:' \
+            '        process.wait(timeout=2)' \
+            '    except subprocess.TimeoutExpired:' \
+            '        os.killpg(process.pid, signal.SIGKILL)' \
+            '        process.wait()' \
+            '    status = 124' \
+            'def group_exists():' \
+            '    try:' \
+            '        os.killpg(process.pid, 0)' \
+            '        return True' \
+            '    except ProcessLookupError:' \
+            '        return False' \
+            'if group_exists():' \
+            '    os.killpg(process.pid, signal.SIGTERM)' \
+            '    deadline = time.monotonic() + 2' \
+            '    while group_exists() and time.monotonic() < deadline:' \
+            '        time.sleep(0.05)' \
+            '    if group_exists():' \
+            '        os.killpg(process.pid, signal.SIGKILL)' \
+            'sys.exit(status)' > "$runner"
+
+      - name: Download exact published release archive
+        id: download
+        shell: bash
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -uo pipefail
+          set +e
+          artifact_dir="${RUNNER_TEMP}/artifact-smoke"
+          timeout_marker="${RUNNER_TEMP}/.download_timed_out"
+          mkdir -p "$artifact_dir"
+          rm -f "$timeout_marker"
+          echo "Downloading ${GOOS}/${GOARCH} from exact release $GITHUB_REPOSITORY@$RELEASE_TAG"
+          python3 "${RUNNER_TEMP}/cicd-run-with-timeout.py" 120 "$timeout_marker" \
+            gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern "*_${GOOS}_${GOARCH}.tar.gz" \
+            --pattern "*_${GOOS}_${GOARCH}.tgz" \
+            --pattern "*_${GOOS}_${GOARCH}.zip" \
+            --dir "$artifact_dir" --clobber
+          status=$?
+          if [ -f "$timeout_marker" ]; then
+            echo "::error::Could not download the exact $RELEASE_TAG ${GOOS}/${GOARCH} published archive within 120 seconds; no artifact was executed."
+            exit 1
+          fi
+          if [ "$status" -ne 0 ]; then
+            echo "::error::No ${GOOS}/${GOARCH} published archive matched exact release $RELEASE_TAG; no artifact was executed."
+            exit 1
+          fi
+          archive="$(find "$artifact_dir" -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.tgz' -o -name '*.zip' \) | head -n1)"
+          if [ -z "$archive" ]; then
+            echo "::error::The exact $RELEASE_TAG download contained no recognized ${GOOS}/${GOARCH} archive; no artifact was executed."
+            exit 1
+          fi
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Extract exact published release archive
+        id: extract
+        shell: bash
+        env:
+          ARCHIVE: ${{ steps.download.outputs.archive }}
+        run: |
+          set -euo pipefail
+          extract_dir="${RUNNER_TEMP}/artifact-smoke/extracted"
+          mkdir -p "$extract_dir"
+          case "$ARCHIVE" in
+            *.zip) unzip -o -q "$ARCHIVE" -d "$extract_dir" ;;
+            *.tar.gz|*.tgz) tar xzf "$ARCHIVE" -C "$extract_dir" ;;
+            *) echo "::error::Unrecognized archive '$ARCHIVE'; no artifact was executed."; exit 1 ;;
+          esac
+          bin_path="$(find "$extract_dir" -maxdepth 3 -type f -name "$ARTIFACT_BINARY" | head -n1)"
+          if [ -z "$bin_path" ] || [ ! -f "$bin_path" ]; then
+            echo "::error::Exact release $RELEASE_TAG archive did not contain '$ARTIFACT_BINARY'; no artifact was executed."
+            exit 1
+          fi
+          bin_path="$(cd "$(dirname "$bin_path")" && pwd -P)/$(basename "$bin_path")"
+          chmod +x "$bin_path"
+          echo "bin_path=$bin_path" >> "$GITHUB_OUTPUT"
+
+      - name: Run exact published executable
+        shell: bash
+        env:
+          BIN_PATH: ${{ steps.extract.outputs.bin_path }}
+        run: |
+          set -uo pipefail
+          set +e
+          timeout_marker="${RUNNER_TEMP}/.artifact_timed_out"
+          rm -f "$timeout_marker"
+          echo "Running exact published artifact: $BIN_PATH $ARTIFACT_COMMAND"
+          # ARTIFACT_COMMAND is a space-separated argument list. Expansion is
+          # intentionally unquoted so ordinary multi-argument commands work.
+          # shellcheck disable=SC2086
+          output="$(python3 "${RUNNER_TEMP}/cicd-run-with-timeout.py" "$ARTIFACT_TIMEOUT_SECONDS" "$timeout_marker" "$BIN_PATH" $ARTIFACT_COMMAND 2>&1)"
+          status=$?
+          printf '%s\n' "$output"
+          if [ -f "$timeout_marker" ]; then
+            echo "::error::Exact release $RELEASE_TAG artifact hung and was killed after ${ARTIFACT_TIMEOUT_SECONDS}s."
+            exit 1
+          fi
+          if [ "$status" -ne 0 ]; then
+            echo "::error::Exact release $RELEASE_TAG artifact exited $status."
+            exit 1
+          fi
+          if [ -z "$(printf '%s' "$output" | tr -d '[:space:]')" ]; then
+            echo "::error::Exact release $RELEASE_TAG artifact exited 0 but printed no output."
+            exit 1
+          fi
+          echo "OK: exact $RELEASE_TAG ${ARTIFACT_BINARY} artifact executed successfully."
+
+      - name: Inspect macOS signing and notarization
+        if: ${{ matrix.goos == 'darwin' }}
+        shell: bash
+        env:
+          BIN_PATH: ${{ steps.extract.outputs.bin_path }}
+        run: |
+          set -uo pipefail
+          set +e
+          codesign_out="$(codesign -dv --verbose=4 "$BIN_PATH" 2>&1)"
+          spctl_out="$(spctl -a -vv "$BIN_PATH" 2>&1)"
+          spctl_status=$?
+          printf '%s\n%s\n' "$codesign_out" "$spctl_out"
+          team_id="$(printf '%s\n' "$codesign_out" | grep '^TeamIdentifier=' | cut -d= -f2-)"
+          problems=""
+          if [ -z "$team_id" ] || [ "$team_id" = "not set" ]; then
+            problems="${problems}no Developer ID; "
+          fi
+          if [ "$spctl_status" -ne 0 ]; then
+            problems="${problems}spctl rejected the binary; "
+          fi
+          if [ -z "$problems" ]; then
+            echo "OK: exact $RELEASE_TAG macOS artifact is signed and passes spctl."
+          elif [ "$REQUIRE_NOTARIZED" = "true" ]; then
+            echo "::error::Exact $RELEASE_TAG macOS artifact is not properly signed/notarized: $problems"
+            exit 1
+          else
+            echo "::warning::Exact $RELEASE_TAG macOS artifact is not properly signed/notarized: $problems"
+          fi

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ coverage, and automatic SemVer tagging.
 | --- | --- | --- |
 | `.github/workflows/workflow.yml` | Reusable workflow (`workflow_call`) | Full Go CI: lint, test (+coverage), build, and version bump. The primary entry point. |
 | `.github/workflows/release.yml` | Reusable workflow (`workflow_call`) | GoReleaser release flow (tag + `goreleaser release`). |
+| `.github/workflows/validate-published-artifact.yml` | Reusable workflow (`workflow_call`) | Read-only, exact-tag validation of already published CLI archives. |
 | `action.yml` | Composite action | Single-job CI for callers that want CI steps inline in their own job. |
 | `default.json` | Renovate preset | Shareable config consumers `extends` to auto-track this repo's tag (see below). |
 
@@ -238,6 +239,36 @@ repos where the executable doesn't match `project_name` or a `-cli`-stripped
 repo name) should set `artifact_smoke_test_binary` explicitly. A repo that
 doesn't publish a runnable CLI binary at all should set
 `artifact_smoke_test: false`.
+
+## Revalidating an existing published artifact
+
+Use `validate-published-artifact.yml` when an already published CLI archive
+needs to be executed again without creating a tag or release. This is separate
+from `release.yml` because reusable-workflow permissions can only stay the same
+or become more restrictive: a `contents: read` validation caller cannot call a
+workflow containing a `contents: write` release job, even when that job would be
+conditionally skipped.
+
+The validation workflow has only `contents: read`, requires the exact release
+tag and executable name, downloads archives only from that tag, and hard-fails
+unless every configured platform reaches and successfully executes the
+published binary. It has no GoReleaser, tag creation, publishing, or Homebrew
+cask path.
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    uses: strongo/cicd/.github/workflows/validate-published-artifact.yml@v1
+    permissions:
+      contents: read
+    with:
+      release_tag: v0.33.0
+      artifact_binary: my-cli
+      artifact_command: --version
+```
 
 Binary-name inference reads `.goreleaser.y*ml`/`goreleaser.y*ml` at the repo
 **root**. A repo using `tag_prefix` for a subdirectory module (e.g.

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -2,7 +2,6 @@ package go_ci_action
 
 import (
 	"fmt"
-	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,7 +10,10 @@ import (
 	"time"
 )
 
-const releaseWorkflowPath = ".github/workflows/release.yml"
+const (
+	releaseWorkflowPath           = ".github/workflows/release.yml"
+	publishedArtifactWorkflowPath = ".github/workflows/validate-published-artifact.yml"
+)
 
 func TestReleaseWorkflowExtractsAnAbsoluteRunnableBinaryPath(t *testing.T) {
 	extractScript := releaseWorkflowRunBlock(t, "Extract published archive")
@@ -78,119 +80,72 @@ func TestReleaseWorkflowExtractsAnAbsoluteRunnableBinaryPath(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowHistoricalArtifactModeSelectsOnlyTheExactRequestedTag(t *testing.T) {
-	validateScript := releaseWorkflowRunBlock(t, "Validate existing artifact tag and release-mode inputs")
-	resolveTagScript := releaseWorkflowRunBlock(t, "Determine the artifact tag to verify")
+func TestPublishedArtifactWorkflowValidatesTheExactRequestedTag(t *testing.T) {
+	validateScript := publishedArtifactWorkflowRunBlock(t, "Validate exact release tag and platforms")
 
 	for _, tc := range []struct {
 		name       string
-		env        map[string]string
+		releaseTag string
+		tagPrefix  string
 		wantStatus int
 		wantTag    string
 	}{
 		{
-			name: "valid plain semver tag",
-			env: map[string]string{
-				"EXISTING_ARTIFACT_TAG":    "v0.33.0",
-				"TAG_PREFIX":               "v",
-				"DEFAULT_BUMP":             "false",
-				"ALLOW_MAJOR_VERSION_BUMP": "false",
-				"GORELEASER_EXTRA_ARGS":    "",
-				"GITHUB_REF_TYPE":          "branch",
-			},
+			name:       "valid plain semver tag",
+			releaseTag: "v0.33.0",
+			tagPrefix:  "v",
 			wantStatus: 0,
 			wantTag:    "v0.33.0",
 		},
 		{
-			name: "scoped prefix",
-			env: map[string]string{
-				"EXISTING_ARTIFACT_TAG":    "ingitdb/v0.33.0",
-				"TAG_PREFIX":               "ingitdb/v",
-				"DEFAULT_BUMP":             "false",
-				"ALLOW_MAJOR_VERSION_BUMP": "false",
-				"GORELEASER_EXTRA_ARGS":    "",
-				"GITHUB_REF_TYPE":          "branch",
-			},
+			name:       "scoped prefix",
+			releaseTag: "ingitdb/v0.33.0",
+			tagPrefix:  "ingitdb/v",
 			wantStatus: 0,
 			wantTag:    "ingitdb/v0.33.0",
 		},
 		{
-			name: "rejects invalid semver",
-			env: map[string]string{
-				"EXISTING_ARTIFACT_TAG":    "v0.33",
-				"TAG_PREFIX":               "v",
-				"DEFAULT_BUMP":             "false",
-				"ALLOW_MAJOR_VERSION_BUMP": "false",
-				"GORELEASER_EXTRA_ARGS":    "",
-				"GITHUB_REF_TYPE":          "branch",
-			},
+			name:       "rejects invalid semver",
+			releaseTag: "v0.33",
+			tagPrefix:  "v",
 			wantStatus: 1,
 		},
 		{
-			name: "rejects semver component with leading zero",
-			env: map[string]string{
-				"EXISTING_ARTIFACT_TAG":    "v01.2.3",
-				"TAG_PREFIX":               "v",
-				"DEFAULT_BUMP":             "false",
-				"ALLOW_MAJOR_VERSION_BUMP": "false",
-				"GORELEASER_EXTRA_ARGS":    "",
-				"GITHUB_REF_TYPE":          "branch",
-			},
-			wantStatus: 1,
-		},
-		{
-			name: "rejects release mode conflict",
-			env: map[string]string{
-				"EXISTING_ARTIFACT_TAG":    "v0.33.0",
-				"TAG_PREFIX":               "v",
-				"DEFAULT_BUMP":             "patch",
-				"ALLOW_MAJOR_VERSION_BUMP": "false",
-				"GORELEASER_EXTRA_ARGS":    "",
-				"GITHUB_REF_TYPE":          "branch",
-			},
+			name:       "rejects semver component with leading zero",
+			releaseTag: "v01.2.3",
+			tagPrefix:  "v",
 			wantStatus: 1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			outputFile := filepath.Join(t.TempDir(), "github-output")
-			env := maps.Clone(tc.env)
-			env["GITHUB_OUTPUT"] = outputFile
-			env["ARTIFACT_SMOKE_TEST"] = "true"
-			env["ARTIFACT_SMOKE_TEST_PLATFORMS"] = `[{"runner":"ubuntu-latest","goos":"linux","goarch":"amd64"}]`
+			env := map[string]string{
+				"RELEASE_TAG":        tc.releaseTag,
+				"TAG_PREFIX":         tc.tagPrefix,
+				"ARTIFACT_BINARY":    "specscore",
+				"ARTIFACT_PLATFORMS": `[{"runner":"ubuntu-latest","goos":"linux","goarch":"amd64"}]`,
+				"GITHUB_OUTPUT":      outputFile,
+			}
 			output, err := runBash(t.TempDir(), validateScript, env)
 			if tc.wantStatus == 0 {
 				if err != nil {
-					t.Fatalf("validate historical mode: %v\n%s", err, output)
+					t.Fatalf("validate published artifact request: %v\n%s", err, output)
 				}
-				if got := githubOutput(t, outputFile, "existing_artifact_tag"); got != tc.wantTag {
+				if got := githubOutput(t, outputFile, "release_tag"); got != tc.wantTag {
 					t.Fatalf("validated tag = %q, want %q", got, tc.wantTag)
 				}
 				return
 			}
 			if err == nil {
-				t.Fatalf("invalid historical mode succeeded:\n%s", output)
+				t.Fatalf("invalid published-artifact request succeeded:\n%s", output)
 			}
 		})
 	}
-
-	outputFile := filepath.Join(t.TempDir(), "github-output")
-	output, err := runBash(t.TempDir(), resolveTagScript, map[string]string{
-		"EXISTING_ARTIFACT_TAG": "v0.33.0",
-		"RELEASE_TAG":           "v99.99.99",
-		"GITHUB_REF_NAME":       "main",
-		"GITHUB_OUTPUT":         outputFile,
-	})
-	if err != nil {
-		t.Fatalf("resolve exact historical tag: %v\n%s", err, output)
-	}
-	if got := githubOutput(t, outputFile, "tag"); got != "v0.33.0" {
-		t.Fatalf("resolver fell back from requested historical tag: got %q, want %q", got, "v0.33.0")
-	}
 }
 
-func TestReleaseWorkflowHistoricalArtifactCannotPassWithoutExecutingAnArtifact(t *testing.T) {
-	downloadScript := localWorkflowScript(releaseWorkflowRunBlock(t, "Download published release asset"))
-	extractScript := localWorkflowScript(releaseWorkflowRunBlock(t, "Extract published archive"))
+func TestPublishedArtifactWorkflowCannotPassWithoutExecutingAnArtifact(t *testing.T) {
+	downloadScript := publishedArtifactWorkflowRunBlock(t, "Download exact published release archive")
+	extractScript := publishedArtifactWorkflowRunBlock(t, "Extract exact published release archive")
 
 	t.Run("missing GitHub release or archive", func(t *testing.T) {
 		workspace := t.TempDir()
@@ -199,28 +154,41 @@ func TestReleaseWorkflowHistoricalArtifactCannotPassWithoutExecutingAnArtifact(t
 			t.Fatal(err)
 		}
 		writeExecutable(t, filepath.Join(fakeBin, "gh"), "#!/usr/bin/env bash\nexit 1\n")
+		preparePublishedArtifactRunner(t, workspace)
 
 		baseEnv := map[string]string{
 			"PATH":              fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
 			"RUNNER_TEMP":       workspace,
 			"GITHUB_REPOSITORY": "specscore/specscore-cli",
-			"TAG":               "v0.33.0",
+			"RELEASE_TAG":       "v0.33.0",
+			"GOOS":              "linux",
+			"GOARCH":            "amd64",
 		}
-		assertHistoricalFailureAndNormalSkip(t, workspace, downloadScript, baseEnv, "asset_found")
+		assertWorkflowFailure(t, workspace, downloadScript, baseEnv)
+	})
+
+	t.Run("download command returns success without an archive", func(t *testing.T) {
+		workspace := t.TempDir()
+		fakeBin := filepath.Join(workspace, "fake-bin")
+		if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeExecutable(t, filepath.Join(fakeBin, "gh"), "#!/usr/bin/env bash\nexit 0\n")
+		preparePublishedArtifactRunner(t, workspace)
+		assertWorkflowFailure(t, workspace, downloadScript, map[string]string{
+			"PATH":              fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+			"RUNNER_TEMP":       workspace,
+			"GITHUB_REPOSITORY": "specscore/specscore-cli",
+			"RELEASE_TAG":       "v0.33.0",
+			"GOOS":              "linux",
+			"GOARCH":            "amd64",
+		})
 	})
 
 	for _, tc := range []struct {
 		name    string
 		prepare func(*testing.T, string)
 	}{
-		{
-			name: "downloaded set has no recognized archive",
-			prepare: func(t *testing.T, workspace string) {
-				if err := os.WriteFile(filepath.Join(workspace, "checksums.txt"), []byte("sidecar"), 0o644); err != nil {
-					t.Fatal(err)
-				}
-			},
-		},
 		{
 			name: "archive extraction fails",
 			prepare: func(t *testing.T, workspace string) {
@@ -246,14 +214,17 @@ func TestReleaseWorkflowHistoricalArtifactCannotPassWithoutExecutingAnArtifact(t
 		t.Run(tc.name, func(t *testing.T) {
 			workspace := t.TempDir()
 			tc.prepare(t, workspace)
-			assertHistoricalFailureAndNormalSkip(t, workspace, extractScript, map[string]string{
-				"BINARY": "specscore",
-			}, "extracted")
+			assertWorkflowFailure(t, workspace, extractScript, map[string]string{
+				"ARCHIVE":         filepath.Join(workspace, "specscore_linux_amd64.tar.gz"),
+				"ARTIFACT_BINARY": "specscore",
+				"RELEASE_TAG":     "v0.33.0",
+				"RUNNER_TEMP":     workspace,
+			})
 		})
 	}
 }
 
-func TestReleaseWorkflowSuccessfulHistoricalValidationInvokesExecutable(t *testing.T) {
+func TestPublishedArtifactWorkflowSuccessInvokesExecutable(t *testing.T) {
 	workspace := t.TempDir()
 	payloadDir := filepath.Join(workspace, "payload")
 	if err := os.MkdirAll(payloadDir, 0o755); err != nil {
@@ -268,82 +239,184 @@ func TestReleaseWorkflowSuccessfulHistoricalValidationInvokesExecutable(t *testi
 	}
 
 	extractOutput := filepath.Join(workspace, "extract-output")
-	extractScript := localWorkflowScript(releaseWorkflowRunBlock(t, "Extract published archive"))
+	extractScript := publishedArtifactWorkflowRunBlock(t, "Extract exact published release archive")
 	if output, err := runBash(workspace, extractScript, map[string]string{
-		"BINARY":                         "specscore",
-		"GITHUB_OUTPUT":                  extractOutput,
-		"HISTORICAL_ARTIFACT_VALIDATION": "true",
+		"ARCHIVE":         archivePath,
+		"ARTIFACT_BINARY": "specscore",
+		"RELEASE_TAG":     "v0.33.0",
+		"RUNNER_TEMP":     workspace,
+		"GITHUB_OUTPUT":   extractOutput,
 	}); err != nil {
-		t.Fatalf("extract valid historical artifact: %v\n%s", err, output)
+		t.Fatalf("extract valid published artifact: %v\n%s", err, output)
 	}
 
-	runScript := localWorkflowScript(releaseWorkflowRunBlock(t, "'Layer 1: run the published binary (must exit within timeout)'"))
+	preparePublishedArtifactRunner(t, workspace)
+	runScript := publishedArtifactWorkflowRunBlock(t, "Run exact published executable")
 	output, err := runBash(workspace, runScript, map[string]string{
-		"BIN_PATH":        githubOutput(t, extractOutput, "bin_path"),
-		"SMOKE_CMD":       "--version",
-		"TIMEOUT_SECONDS": "2",
-		"INVOKED_FILE":    invokedFile,
+		"BIN_PATH":                 githubOutput(t, extractOutput, "bin_path"),
+		"ARTIFACT_BINARY":          "specscore",
+		"ARTIFACT_COMMAND":         "--version",
+		"ARTIFACT_TIMEOUT_SECONDS": "2",
+		"RELEASE_TAG":              "v0.33.0",
+		"RUNNER_TEMP":              workspace,
+		"INVOKED_FILE":             invokedFile,
 	})
 	if err != nil {
-		t.Fatalf("run valid historical artifact: %v\n%s", err, output)
+		t.Fatalf("run valid published artifact: %v\n%s", err, output)
 	}
 	if _, err := os.Stat(invokedFile); err != nil {
-		t.Fatalf("successful historical validation did not invoke the executable: %v\n%s", err, output)
+		t.Fatalf("successful published-artifact validation did not invoke the executable: %v\n%s", err, output)
 	}
 }
 
-func assertHistoricalFailureAndNormalSkip(t *testing.T, workspace, script string, baseEnv map[string]string, outputKey string) {
-	t.Helper()
+func TestReleaseWorkflowKeepsWarningSkipBehaviorForUntestableArtifacts(t *testing.T) {
+	downloadScript := releaseWorkflowRunBlock(t, "Download published release asset")
+	downloadScript = strings.ReplaceAll(downloadScript, "${{ matrix.goos }}", "linux")
+	downloadScript = strings.ReplaceAll(downloadScript, "${{ matrix.goarch }}", "amd64")
+
+	t.Run("missing release archive", func(t *testing.T) {
+		workspace := t.TempDir()
+		fakeBin := filepath.Join(workspace, "fake-bin")
+		if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeExecutable(t, filepath.Join(fakeBin, "gh"), "#!/usr/bin/env bash\nexit 1\n")
+		outputFile := filepath.Join(workspace, "github-output")
+		output, err := runBash(workspace, downloadScript, map[string]string{
+			"PATH":              fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+			"RUNNER_TEMP":       workspace,
+			"GITHUB_OUTPUT":     outputFile,
+			"GITHUB_REPOSITORY": "specscore/specscore-cli",
+			"TAG":               "v0.33.0",
+		})
+		if err != nil {
+			t.Fatalf("normal release download must warn and skip: %v\n%s", err, output)
+		}
+		if got := githubOutput(t, outputFile, "asset_found"); got != "false" {
+			t.Fatalf("asset_found = %q, want false\n%s", got, output)
+		}
+		if !strings.Contains(string(output), "::warning::Could not test linux/amd64") {
+			t.Fatalf("normal release download did not retain warning taxonomy:\n%s", output)
+		}
+	})
+
+	extractScript := releaseWorkflowRunBlock(t, "Extract published archive")
+	extractScript = strings.ReplaceAll(extractScript, "${{ matrix.goos }}", "linux")
+	extractScript = strings.ReplaceAll(extractScript, "${{ matrix.goarch }}", "amd64")
 	for _, tc := range []struct {
-		name       string
-		historical string
-		wantError  bool
+		name    string
+		prepare func(*testing.T, string)
 	}{
-		{name: "historical mode fails", historical: "true", wantError: true},
-		{name: "normal release mode keeps warning skip", historical: "false", wantError: false},
+		{
+			name: "download has no recognized archive",
+			prepare: func(*testing.T, string) {
+			},
+		},
+		{
+			name: "archive extraction fails",
+			prepare: func(t *testing.T, workspace string) {
+				if err := os.WriteFile(filepath.Join(workspace, "specscore_linux_amd64.tar.gz"), []byte("not an archive"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "archive has no resolved binary",
+			prepare: func(t *testing.T, workspace string) {
+				if err := os.WriteFile(filepath.Join(workspace, "README.md"), []byte("no executable here"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				archive := exec.Command("tar", "-C", workspace, "-czf", filepath.Join(workspace, "specscore_linux_amd64.tar.gz"), "README.md")
+				if output, err := archive.CombinedOutput(); err != nil {
+					t.Fatalf("create archive without binary: %v\n%s", err, output)
+				}
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			outputFile := filepath.Join(workspace, strings.ReplaceAll(tc.name, " ", "-")+"-output")
-			env := maps.Clone(baseEnv)
-			env["GITHUB_OUTPUT"] = outputFile
-			env["HISTORICAL_ARTIFACT_VALIDATION"] = tc.historical
-			output, err := runBash(workspace, script, env)
-			if tc.wantError {
-				if err == nil {
-					t.Fatalf("historical could-not-test path passed:\n%s", output)
-				}
-				return
-			}
+			workspace := t.TempDir()
+			tc.prepare(t, workspace)
+			outputFile := filepath.Join(workspace, "github-output")
+			output, err := runBash(workspace, extractScript, map[string]string{
+				"BINARY":        "specscore",
+				"RUNNER_TEMP":   workspace,
+				"GITHUB_OUTPUT": outputFile,
+			})
 			if err != nil {
-				t.Fatalf("normal release could-not-test path no longer soft-skips: %v\n%s", err, output)
+				t.Fatalf("normal release extraction must warn and skip: %v\n%s", err, output)
 			}
-			if got := githubOutput(t, outputFile, outputKey); got != "false" {
-				t.Fatalf("normal release %s = %q, want false", outputKey, got)
+			if got := githubOutput(t, outputFile, "extracted"); got != "false" {
+				t.Fatalf("extracted = %q, want false\n%s", got, output)
+			}
+			if !strings.Contains(string(output), "::warning::Could not test linux/amd64") {
+				t.Fatalf("normal release extraction did not retain warning taxonomy:\n%s", output)
 			}
 		})
 	}
 }
 
-func localWorkflowScript(script string) string {
-	replacer := strings.NewReplacer(
-		"${{ matrix.goos }}", "linux",
-		"${{ matrix.goarch }}", "amd64",
-	)
-	return replacer.Replace(script)
+func assertWorkflowFailure(t *testing.T, workspace, script string, variables map[string]string) {
+	t.Helper()
+	output, err := runBash(workspace, script, variables)
+	if err == nil {
+		t.Fatalf("published-artifact validation passed without executing an artifact:\n%s", output)
+	}
 }
 
-func TestReleaseWorkflowHistoricalArtifactModeSkipsPublishingAndHomebrew(t *testing.T) {
-	workflow := readReleaseWorkflow(t)
-	for _, want := range []string{
-		"if: ${{ needs.validate_release_mode.result == 'success' && inputs.existing_artifact_tag == '' }}",
-		"${{ always() && !cancelled() &&",
-		"inputs.existing_artifact_tag != '' ||",
-		"inputs.existing_artifact_tag == '' &&",
-		"ref: ${{ steps.release_tag.outputs.tag }}",
+func preparePublishedArtifactRunner(t *testing.T, workspace string) {
+	t.Helper()
+	script := publishedArtifactWorkflowRunBlock(t, "Prepare bounded process runner")
+	if output, err := runBash(workspace, script, map[string]string{"RUNNER_TEMP": workspace}); err != nil {
+		t.Fatalf("prepare bounded process runner: %v\n%s", err, output)
+	}
+}
+
+func TestPublishedArtifactBoundedRunnerReapsForkedDescendants(t *testing.T) {
+	workspace := t.TempDir()
+	preparePublishedArtifactRunner(t, workspace)
+	childPIDFile := filepath.Join(workspace, "child-pid")
+	program := `python3 "$RUNNER_TEMP/cicd-run-with-timeout.py" 2 "$RUNNER_TEMP/timeout" bash -c '(while :; do :; done) & printf "%s\n" "$!" > "$CHILD_PID_FILE"; printf complete'`
+	started := time.Now()
+	output, err := runBash(workspace, program, map[string]string{
+		"RUNNER_TEMP":    workspace,
+		"CHILD_PID_FILE": childPIDFile,
+	})
+	if err != nil {
+		t.Fatalf("bounded runner: %v\n%s", err, output)
+	}
+	if elapsed := time.Since(started); elapsed >= 1500*time.Millisecond {
+		t.Fatalf("bounded runner waited %s after command leader exited\n%s", elapsed, output)
+	}
+	childPID := readPID(t, childPIDFile)
+	t.Cleanup(func() { killProcess(childPID) })
+	if processIsAlive(childPID) {
+		t.Fatalf("bounded runner left child process %d alive", childPID)
+	}
+}
+
+func TestPublishedArtifactWorkflowIsReadOnlyAndNonPublishing(t *testing.T) {
+	workflow := readPublishedArtifactWorkflow(t)
+	if !strings.Contains(workflow, "permissions:\n  contents: read\n") {
+		t.Fatal("published-artifact reusable workflow must declare contents: read")
+	}
+	for _, forbidden := range []string{
+		"contents: write",
+		"goreleaser-action",
+		"git tag",
+		"git push",
+		"brew install",
 	} {
-		if !strings.Contains(workflow, want) {
-			t.Fatalf("workflow does not preserve historical artifact safety contract %q", want)
+		if strings.Contains(workflow, forbidden) {
+			t.Fatalf("read-only published-artifact workflow contains publishing capability %q", forbidden)
 		}
+	}
+
+	releaseWorkflow := readReleaseWorkflow(t)
+	if strings.Contains(releaseWorkflow, "existing_artifact_tag") {
+		t.Fatal("write-capable release workflow must not expose historical validation mode")
+	}
+	if !strings.Contains(releaseWorkflow, "contents: write   # required for GoReleaser to push GitHub releases") {
+		t.Fatal("normal release workflow lost its required write permission")
 	}
 }
 
@@ -559,7 +632,16 @@ func killProcess(pid int) {
 
 func releaseWorkflowRunBlock(t *testing.T, stepName string) string {
 	t.Helper()
-	workflow := readReleaseWorkflow(t)
+	return namedWorkflowRunBlock(t, readReleaseWorkflow(t), stepName)
+}
+
+func publishedArtifactWorkflowRunBlock(t *testing.T, stepName string) string {
+	t.Helper()
+	return namedWorkflowRunBlock(t, readPublishedArtifactWorkflow(t), stepName)
+}
+
+func namedWorkflowRunBlock(t *testing.T, workflow, stepName string) string {
+	t.Helper()
 	needle := "      - name: " + stepName
 	start := strings.Index(workflow, needle)
 	if start == -1 {
@@ -616,6 +698,15 @@ func yamlRunBlock(t *testing.T, text string) string {
 func readReleaseWorkflow(t *testing.T) string {
 	t.Helper()
 	workflow, err := os.ReadFile(releaseWorkflowPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(workflow)
+}
+
+func readPublishedArtifactWorkflow(t *testing.T) string {
+	t.Helper()
+	workflow, err := os.ReadFile(publishedArtifactWorkflowPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- add a dedicated reusable historical-artifact validator whose maximum permission is `contents: read`
- validate one exact `tag_prefix` + plain SemVer tag and execute every configured published archive; missing release/archive, extraction failure, missing binary, timeout, nonzero exit, and empty output all fail
- remove historical validation from the write-capable release workflow and restore normal release behavior exactly, including its existing warning/skip taxonomy
- keep tagging, GoReleaser, publishing, and Homebrew-cask installation entirely out of the read-only path

## Root cause

GitHub validates a called workflow's maximum permissions before evaluating job conditions. A `contents: read` caller therefore cannot call the release workflow while it contains a `contents: write` release job, even when historical mode would skip that job. SpecScore CLI run 31492969803 failed at workflow startup with zero jobs for this reason.

## Validation

- `actionlint -color`
- `go test -count=1 ./...`
- `go test ./...`
- `git diff --check`
- `wb --non-interactive check . --profile full` (lint, test, build)
- normal-release backward compatibility is behavior-tested for missing downloads, corrupt archives, and missing binaries

## Dependency order

This PR must merge first. Then create and verify the next backward-compatible strongo/cicd release, advance `strongo/cicd@v1` to the merged commit, and read back both the remote ref and `.github/workflows/validate-published-artifact.yml` before merging or dispatching the dependent SpecScore caller PR. This PR does not move or recreate any tag.
