### PR TITLE
ci: pin golangci-lint to v2.12.2 and revert Go to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,19 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          # PINNED TOGETHER WITH golangci-lint BELOW -- these two versions are
+          # not independent. golangci-lint must be built with a Go at least as
+          # new as the toolchain it analyses, or it cannot typecheck the
+          # standard library ("unknown field rfd in struct literal of type
+          # splicePipe" from internal/poll, on v2.12.2 against Go 1.27).
+          #
+          # Renovate raised this to 1.27 in 4576f10 on 2026-08-20. Combined
+          # with golangci v2.13.0 landing the same morning, that turned the
+          # whole Go fleet red. Back to 1.26, which is also what the consumer
+          # modules actually declare (sneat-go go.mod: 1.26.1,
+          # sneat-core-modules: 1.26) -- linting them under 1.27 was ahead of
+          # the code being linted. Raise both versions together, deliberately.
+          go-version: '1.26'
           cache: false
 
       - uses: ./

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -222,7 +222,27 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          #          version: v2.0
+          # PINNED. Without this the action resolves "latest" at run time, so a
+          # golangci-lint release turns every Go repo in the fleet red at once
+          # with no change on our side. That happened on 2026-08-20: v2.13.0
+          # superseded v2.12.2 and broke two repos in different ways, both
+          # traced to the staticcheck release candidate it bundles
+          # (honnef.co/go/tools v0.8.0-rc.1):
+          #
+          #   sneat-go            the nilness analyzer PANICS -- "internal
+          #                       error: unhandled builtin recover" -- while
+          #                       analysing the third-party sentry package, and
+          #                       the run then times out. No change to our own
+          #                       code can fix an analyzer crash.
+          #   sneat-core-modules  new SA4023 findings in auth/api4auth. True
+          #                       positives, but on long-dead Facebook sign-in
+          #                       code whose only non-panicking exits already
+          #                       return a non-nil error.
+          #
+          # A release candidate analyzer is not a thing to gate every merge on.
+          # Bump this deliberately once v2.13.x ships a stable staticcheck, and
+          # expect to fix the SA4023 findings as part of that bump.
+          version: v2.12.2
 
           args: --timeout=${{ inputs.lint-timeout }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -163,7 +163,19 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          # PINNED TOGETHER WITH golangci-lint BELOW -- these two versions are
+          # not independent. golangci-lint must be built with a Go at least as
+          # new as the toolchain it analyses, or it cannot typecheck the
+          # standard library ("unknown field rfd in struct literal of type
+          # splicePipe" from internal/poll, on v2.12.2 against Go 1.27).
+          #
+          # Renovate raised this to 1.27 in 4576f10 on 2026-08-20. Combined
+          # with golangci v2.13.0 landing the same morning, that turned the
+          # whole Go fleet red. Back to 1.26, which is also what the consumer
+          # modules actually declare (sneat-go go.mod: 1.26.1,
+          # sneat-core-modules: 1.26) -- linting them under 1.27 was ahead of
+          # the code being linted. Raise both versions together, deliberately.
+          go-version: '1.26'
           # Cache restore/save is owned explicitly below. Letting setup-go save
           # from both parallel jobs causes a cold-cache reservation race.
           cache: false
@@ -281,7 +293,19 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.27'
+          # PINNED TOGETHER WITH golangci-lint BELOW -- these two versions are
+          # not independent. golangci-lint must be built with a Go at least as
+          # new as the toolchain it analyses, or it cannot typecheck the
+          # standard library ("unknown field rfd in struct literal of type
+          # splicePipe" from internal/poll, on v2.12.2 against Go 1.27).
+          #
+          # Renovate raised this to 1.27 in 4576f10 on 2026-08-20. Combined
+          # with golangci v2.13.0 landing the same morning, that turned the
+          # whole Go fleet red. Back to 1.26, which is also what the consumer
+          # modules actually declare (sneat-go go.mod: 1.26.1,
+          # sneat-core-modules: 1.26) -- linting them under 1.27 was ahead of
+          # the code being linted. Raise both versions together, deliberately.
+          go-version: '1.26'
           # The Build & test job is the sole writer for the shared Go cache;
           # see the matching restore in Lint above.
           cache: false


### PR DESCRIPTION
## The whole Go fleet is red, and nobody wrote any code to cause it

`sneat-go` and `sneat-core-modules` `main` have both been failing lint since their last merges (#997 and #155), and every branch cut from them inherits it. Two things landed on 2026-08-20 that are only broken **in combination**:

```
2026-08-19 22:32   Go 1.26 + golangci v2.12.2                          fleet green
2026-08-20 07:57   Renovate 4576f10 raises this workflow's go-version
                   to 1.27. golangci "latest" is v2.13.0 by then, so
                   cicd's own small Go codebase still passes            looks fine
2026-08-20 12:44   consumers now lint under Go 1.27 + v2.13.0           fleet red
```

Two unpinned versions, one automated bump, and the breakage surfaces in *other* repositories hours later.

## Why both versions have to move together

`version:` was commented out, so `golangci-lint-action@v9` resolved **`latest` at run time**. And `go-version` is **hardcoded here**, so a single Renovate commit moved every consumer's lint toolchain at once — whatever their own `go.mod` says.

**The first commit on this branch pinned only golangci-lint to v2.12.2, and this PR's own CI proved that wrong:**

```
/opt/hostedtoolcache/go/1.27.0/x64/src/internal/poll/splice_linux.go:237:21:
  unknown field rfd in struct literal of type splicePipe (typecheck)
```

golangci-lint must be built with a Go at least as new as the toolchain it analyses, so v2.12.2 cannot typecheck the Go 1.27 standard library. The second commit reverts Go to 1.26 as well. Lint is green on this branch now.

## Why revert Go rather than keep 1.27

Staying on Go 1.27 means staying on golangci v2.13.0 — and v2.13.0 bundles the staticcheck **release candidate** `honnef.co/go/tools v0.8.0-rc.1`, which **cannot lint `sneat-go` at all**:

```
level=error msg="[runner] Panic: nilness: package \"sentry\" (isInitialPkg: false,
  needAnalyzeSource: true): internal error: unhandled builtin recover
...
honnef.co/go/tools@v0.8.0-rc.1/analysis/facts/nilness/nilness.go:361
level=error msg="Running error: can't run linter goanalysis_metalinter"
```

The analyzer panics inside the third-party `sentry` package. No change to our own code can fix that, and raising `--timeout` only makes it take longer to fail.

It also raised new `SA4023` findings in `sneat-core-modules`' `auth/api4auth`. I checked those rather than assuming: they are **true positives**, but about long-dead code — `signInFbUser`'s only non-panicking exits already `return` a non-nil error, the other branches being `panic("not imlemented")`. Real, but not a regression, and not something to fix under time pressure to unblock unrelated merges.

**And 1.26 is what the consumers actually declare** — `sneat-go` `go.mod` is `1.26.1`, `sneat-core-modules` is `1.26`. Linting them under 1.27 was running ahead of the code being linted.

So this returns the fleet to the exact configuration that was green 24 hours ago, with both versions now explicit instead of floating.

## Follow-up

Raise Go and golangci **together**, deliberately, once v2.13.x ships a stable staticcheck — and fix the `SA4023` findings as part of that bump, with the Facebook sign-in code either implemented or deleted.

Worth considering separately: making `go-version` a workflow input with a default, so one repo can move ahead without moving all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rk9aS2pdhSXr1Xr9kpSmyS
