### PR TITLE
build: bump Go to 1.27.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
           # modules actually declare (sneat-go go.mod: 1.26.1,
           # sneat-core-modules: 1.26) -- linting them under 1.27 was ahead of
           # the code being linted. Raise both versions together, deliberately.
-          go-version: '1.27'
+          go-version: '1.27.0'
           cache: false
 
       - uses: ./

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -175,7 +175,7 @@ jobs:
           # modules actually declare (sneat-go go.mod: 1.26.1,
           # sneat-core-modules: 1.26) -- linting them under 1.27 was ahead of
           # the code being linted. Raise both versions together, deliberately.
-          go-version: '1.27'
+          go-version: '1.27.0'
           # Cache restore/save is owned explicitly below. Letting setup-go save
           # from both parallel jobs causes a cold-cache reservation race.
           cache: false
@@ -305,7 +305,7 @@ jobs:
           # modules actually declare (sneat-go go.mod: 1.26.1,
           # sneat-core-modules: 1.26) -- linting them under 1.27 was ahead of
           # the code being linted. Raise both versions together, deliberately.
-          go-version: '1.27'
+          go-version: '1.27.0'
           # The Build & test job is the sole writer for the shared Go cache;
           # see the matching restore in Lint above.
           cache: false

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/strongo/go-ci-action
 
-go 1.24.1
+go 1.27.0


### PR DESCRIPTION
Updates Go module and CI toolchain pins to Go 1.27.0.