### PR TITLE
build: bump Go to 1.27.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'   # adjust to your project Go version
+          go-version: '1.27.0' # adjust to your project Go version
 
       - name: Bump version and push tag
         uses: mathieudutour/github-tag-action@v6.2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.27.0'
           cache-dependency-path: ${{ inputs.working_directory }}/go.sum
 
       - run: go get ./...
@@ -143,7 +143,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.27.0'
           cache-dependency-path: ${{ inputs.working_directory }}/go.sum
 
       - if: ${{ inputs.install-firebase-tools }}
@@ -226,7 +226,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.27.0'
           cache-dependency-path: ${{ inputs.working_directory }}/go.sum
 
       - name: Set GitHub access token for GOPRIVATE

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/strongo/go-ci-action
 
-go 1.24.1
+go 1.27.0


### PR DESCRIPTION
Updates Go module and CI toolchain pins to Go 1.27.0.