### PR TITLE
fix(release): pass git-cliff an explicit previous-tag range for the bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,30 @@ jobs:
           make_fixture prefixed-first 'fix: initial release' ''
           make_fixture shallow-source 'fix: release after a shallow checkout'
 
+          # A real (non-squash) merge commit, shaped like the GitHub "Merge
+          # pull request" commits release.yml's callers land day to day
+          # (sneat-dev/wb#160): base tagged v0.1.0, a side branch carrying the
+          # conventional commit, merged back with --no-ff so the merge
+          # commit's own subject stays non-conventional and the introduced
+          # commit is reachable from main only via the merge's second parent.
+          make_merge_fixture() {
+            local name="$1"
+            local message="$2"
+            local repository="$fixture_root/$name"
+            git init --initial-branch=main "$repository"
+            git -C "$repository" config user.email 'release-test@example.invalid'
+            git -C "$repository" config user.name 'Release Test'
+            git -C "$repository" commit --allow-empty -m 'chore: bootstrap'
+            git -C "$repository" tag v0.1.0
+            git -C "$repository" checkout -q -b side
+            git -C "$repository" commit --allow-empty -m "$message"
+            git -C "$repository" checkout -q main
+            git -C "$repository" merge --no-ff -q -m "Merge pull request #1 from side" side
+          }
+
+          make_merge_fixture merge-feat 'feat(cli): add adopt command'
+          make_merge_fixture merge-chore 'docs(cli): note the adopt command'
+
           git clone --depth 1 "file://${fixture_root}/shallow-source" "$fixture_root/shallow-clone"
           test "$(git -C "$fixture_root/shallow-clone" rev-parse --is-shallow-repository)" = 'true'
           test -z "$(git -C "$fixture_root/shallow-clone" tag --list 'v*')"
@@ -162,6 +186,69 @@ jobs:
         shell: bash
         env:
           ACTUAL: ${{ steps.docs_only.outputs.content }}
+        run: test "$ACTUAL" = 'v0.1.0'
+
+      # sneat-dev/wb#160: a real (non-squash) merge of PR #159 to sneat-dev/wb
+      # (commit 298b9067c7686a4258b0e59d44d1db5a0e82d50e) landed a feat, the
+      # shared release workflow ran and succeeded, and cut no tag. Against
+      # that repository's actual ~320-commit/~100-tag history, git-cliff's
+      # own auto-detected range for --bumped-version silently dropped the
+      # commits the merge introduced and reported "nothing to bump" -- even
+      # though `git-cliff --unreleased` (used to render the changelog body)
+      # walked the same history and classified those same commits correctly.
+      # The gap did not reproduce against small isolated fixtures of the same
+      # merge topology (tried up to 30 synthetic prior releases), so it is
+      # not pinned here as its own fixture -- it is undocumented git-cliff
+      # behavior that appears tied to history scale/shape in ways this
+      # module cannot cheaply reconstruct. What IS pinned below is the actual
+      # fix release.yml now relies on unconditionally: an EXPLICIT
+      # `<previous-tag>..HEAD` range, which computed the correct v0.47.0
+      # against the real repository and is asserted here against the same
+      # merge topology at fixture scale.
+      - name: Compute a merge-introduced feature version with an explicit range
+        id: merge_feat_explicit
+        uses: orhun/git-cliff-action@v4.8.0
+        with:
+          version: v2.13.1
+          config: ${{ runner.temp }}/cicd-git-cliff.toml
+          args: >-
+            --repository ${{ runner.temp }}/release-calculator-fixtures/merge-feat
+            --bumped-version
+            --tag-pattern ^v[0-9]+\.[0-9]+\.[0-9]+$
+            v0.1.0..HEAD
+
+      - name: Remove git-cliff working directory
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf git-cliff
+
+      - name: Assert the explicit range correctly bumps a merge-introduced feature
+        shell: bash
+        env:
+          ACTUAL: ${{ steps.merge_feat_explicit.outputs.content }}
+        run: test "$ACTUAL" = 'v0.2.0'
+
+      - name: Compute a merge-introduced chore-only version with an explicit range
+        id: merge_chore_explicit
+        uses: orhun/git-cliff-action@v4.8.0
+        with:
+          version: v2.13.1
+          config: ${{ runner.temp }}/cicd-git-cliff.toml
+          args: >-
+            --repository ${{ runner.temp }}/release-calculator-fixtures/merge-chore
+            --bumped-version
+            --tag-pattern ^v[0-9]+\.[0-9]+\.[0-9]+$
+            v0.1.0..HEAD
+
+      - name: Remove git-cliff working directory
+        if: ${{ always() }}
+        shell: bash
+        run: rm -rf git-cliff
+
+      - name: Assert a merge introducing only docs/chores still cuts nothing
+        shell: bash
+        env:
+          ACTUAL: ${{ steps.merge_chore_explicit.outputs.content }}
         run: test "$ACTUAL" = 'v0.1.0'
 
       - name: Compute a first prefixed version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,51 @@ jobs:
               'commit_parsers = [{ message = "^(chore|ci|docs|refactor)(\\(.+\\))?:", skip = true }]'
           } > "${RUNNER_TEMP}/cicd-git-cliff.toml"
 
+      # Resolve the previous release tag once, before computing the bump, and
+      # share it with both this step and the resolver below. git-cliff's own
+      # tag auto-detection for `--bumped-version` has a gap: when a real
+      # (non-squash) merge lands on main, the commits it introduces are
+      # reachable from HEAD only through the merge commit's second parent,
+      # and git-cliff's undirected auto-range silently drops them from the
+      # bump calculation -- reporting no bump at all for a landed feat/fix --
+      # even though `git-cliff --unreleased` (used to render the changelog
+      # body) walks the same history and classifies those very commits
+      # correctly. Empirically verified against sneat-dev/wb#160: commit
+      # 298b9067c7686a4258b0e59d44d1db5a0e82d50e (a merge of a feat+fix PR)
+      # computes "nothing to bump" with an auto-detected range, and the
+      # correct v0.47.0 with an explicit `<previous-tag>..HEAD` range.
+      # Passing that explicit range closes the gap; squash-merge and
+      # direct-push landings are single-parent-only and unaffected either
+      # way.
+      - name: Resolve previous release tag
+        id: previous_tag
+        if: ${{ github.ref_type != 'tag' }}
+        env:
+          PREFIX: ${{ inputs.tag_prefix }}
+        run: |
+          set -euo pipefail
+          latest_tag=""
+          while IFS= read -r candidate_tag; do
+            candidate_version="${candidate_tag#"$PREFIX"}"
+            if [[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              latest_tag="$candidate_tag"
+              break
+            fi
+          done < <(git tag --list "${PREFIX}*" --sort=-v:refname)
+          previous_version="${latest_tag#"$PREFIX"}"
+          if [ -z "$latest_tag" ] || ! [[ "$previous_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            previous_version="0.0.0"
+            latest_tag=""
+          fi
+          # No previous tag means the very first release: leave range empty
+          # so git-cliff falls back to processing full history, same as
+          # before this change.
+          range=""
+          if [ -n "$latest_tag" ]; then
+            range="${latest_tag}..HEAD"
+          fi
+          printf 'latest_tag=%s\nprevious_version=%s\nrange=%s\n' "$latest_tag" "$previous_version" "$range" >> "$GITHUB_OUTPUT"
+
       # The action prints the proposed tag (with the configured prefix) to its
       # `content` output; the resolver below converts it to bare SemVer.
       # A breaking change under v0 is a minor bump. We push with plain git so
@@ -390,6 +435,7 @@ jobs:
           args: >-
             --bumped-version
             --tag-pattern ^${{ inputs.tag_prefix }}[0-9]+\.[0-9]+\.[0-9]+$
+            ${{ steps.previous_tag.outputs.range }}
 
       # git-cliff-action unpacks its binary into ./git-cliff/ inside the
       # caller's checkout and never removes it. Any later step that inspects
@@ -405,6 +451,10 @@ jobs:
         run: rm -rf git-cliff
 
       # Preserve default_bump for callers that explicitly request a release.
+      # previous_version/latest_tag come from the "Resolve previous release
+      # tag" step above rather than being rescanned here, so the range fed to
+      # git-cliff and the baseline this step compares against can never
+      # disagree.
       - name: Resolve configured default bump
         id: resolved_bump
         if: ${{ github.ref == 'refs/heads/main' && github.ref_type != 'tag' }}
@@ -412,6 +462,8 @@ jobs:
           PROPOSED_VERSION: ${{ steps.bump_dry.outputs.content }}
           PREFIX: ${{ inputs.tag_prefix }}
           DEFAULT_BUMP: ${{ inputs.default_bump }}
+          LATEST_TAG: ${{ steps.previous_tag.outputs.latest_tag }}
+          PREVIOUS_VERSION: ${{ steps.previous_tag.outputs.previous_version }}
         run: |
           set -euo pipefail
           version_is_greater() {
@@ -420,19 +472,8 @@ jobs:
             [ "$candidate" != "$baseline" ] &&
               [ "$(printf '%s\n%s\n' "$baseline" "$candidate" | sort -V | tail -n 1)" = "$candidate" ]
           }
-          latest_tag=""
-          while IFS= read -r candidate_tag; do
-            candidate_version="${candidate_tag#"$PREFIX"}"
-            if [[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              latest_tag="$candidate_tag"
-              break
-            fi
-          done < <(git tag --list "${PREFIX}*" --sort=-v:refname)
-          previous_version="${latest_tag#"$PREFIX"}"
-          if [ -z "$latest_tag" ] || ! [[ "$previous_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            previous_version="0.0.0"
-            latest_tag=""
-          fi
+          latest_tag="$LATEST_TAG"
+          previous_version="$PREVIOUS_VERSION"
           proposed_tag="$(printf '%s' "$PROPOSED_VERSION" | tr -d '\r\n')"
           next_version="${proposed_tag#"$PREFIX"}"
           if [[ "$next_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && version_is_greater "$next_version" "$previous_version"; then

--- a/release_workflow_test.go
+++ b/release_workflow_test.go
@@ -147,6 +147,222 @@ esac
 	}
 }
 
+// TestReleaseWorkflowResolvesPreviousReleaseTag exercises the "Resolve
+// previous release tag" step in isolation. It runs before "Compute next
+// version from Git history" so that step can pass git-cliff an EXPLICIT
+// <previous-tag>..HEAD range: git-cliff's own auto-detected range for
+// --bumped-version silently drops conventional commits that reach HEAD only
+// through a merge commit's second parent (sneat-dev/wb#160, empirically
+// reproduced against sneat-dev/wb commit
+// 298b9067c7686a4258b0e59d44d1db5a0e82d50e), even though the same commits
+// are correctly found and classified by `git-cliff --unreleased`. An
+// explicit range closes that gap.
+func TestReleaseWorkflowResolvesPreviousReleaseTag(t *testing.T) {
+	script := releaseWorkflowRunBlock(t, "Resolve previous release tag")
+
+	t.Run("no previous tag yet", func(t *testing.T) {
+		repository := initGitRepo(t)
+		outputFile := filepath.Join(t.TempDir(), "github-output")
+		output, err := runBash(repository, script, map[string]string{
+			"PREFIX":        "v",
+			"GITHUB_OUTPUT": outputFile,
+		})
+		if err != nil {
+			t.Fatalf("resolve previous release tag: %v\n%s", err, output)
+		}
+		if got := githubOutput(t, outputFile, "latest_tag"); got != "" {
+			t.Fatalf("latest_tag = %q, want empty", got)
+		}
+		if got := githubOutput(t, outputFile, "previous_version"); got != "0.0.0" {
+			t.Fatalf("previous_version = %q, want 0.0.0", got)
+		}
+		// No previous tag means the first release: git-cliff must fall back
+		// to processing full history, same as before this change, so the
+		// range passed to it must be empty rather than a bogus "..HEAD".
+		if got := githubOutput(t, outputFile, "range"); got != "" {
+			t.Fatalf("range = %q, want empty for the initial release", got)
+		}
+	})
+
+	t.Run("picks the highest matching tag and builds an explicit range", func(t *testing.T) {
+		repository := initGitRepo(t, "v0.1.0", "v0.2.0", "v0.10.0")
+		outputFile := filepath.Join(t.TempDir(), "github-output")
+		output, err := runBash(repository, script, map[string]string{
+			"PREFIX":        "v",
+			"GITHUB_OUTPUT": outputFile,
+		})
+		if err != nil {
+			t.Fatalf("resolve previous release tag: %v\n%s", err, output)
+		}
+		// --sort=-v:refname is numeric-aware: v0.10.0 outranks v0.2.0.
+		if got := githubOutput(t, outputFile, "latest_tag"); got != "v0.10.0" {
+			t.Fatalf("latest_tag = %q, want v0.10.0", got)
+		}
+		if got := githubOutput(t, outputFile, "previous_version"); got != "0.10.0" {
+			t.Fatalf("previous_version = %q, want 0.10.0", got)
+		}
+		if got := githubOutput(t, outputFile, "range"); got != "v0.10.0..HEAD" {
+			t.Fatalf("range = %q, want v0.10.0..HEAD", got)
+		}
+	})
+
+	t.Run("ignores tags outside the configured prefix", func(t *testing.T) {
+		repository := initGitRepo(t, "backend/v0.9.0")
+		outputFile := filepath.Join(t.TempDir(), "github-output")
+		output, err := runBash(repository, script, map[string]string{
+			"PREFIX":        "v",
+			"GITHUB_OUTPUT": outputFile,
+		})
+		if err != nil {
+			t.Fatalf("resolve previous release tag: %v\n%s", err, output)
+		}
+		if got := githubOutput(t, outputFile, "latest_tag"); got != "" {
+			t.Fatalf("latest_tag = %q, want empty (backend/v0.9.0 does not match prefix %q)", got, "v")
+		}
+	})
+
+	t.Run("scoped prefix with a slash", func(t *testing.T) {
+		repository := initGitRepo(t, "backend/v0.5.0")
+		outputFile := filepath.Join(t.TempDir(), "github-output")
+		output, err := runBash(repository, script, map[string]string{
+			"PREFIX":        "backend/v",
+			"GITHUB_OUTPUT": outputFile,
+		})
+		if err != nil {
+			t.Fatalf("resolve previous release tag: %v\n%s", err, output)
+		}
+		if got := githubOutput(t, outputFile, "latest_tag"); got != "backend/v0.5.0" {
+			t.Fatalf("latest_tag = %q, want backend/v0.5.0", got)
+		}
+		if got := githubOutput(t, outputFile, "range"); got != "backend/v0.5.0..HEAD" {
+			t.Fatalf("range = %q, want backend/v0.5.0..HEAD", got)
+		}
+	})
+}
+
+// TestReleaseWorkflowResolvesConfiguredDefaultBumpFromSharedPreviousTag locks
+// in the "Resolve configured default bump" step's post-refactor contract: it
+// now consumes LATEST_TAG/PREVIOUS_VERSION from the "Resolve previous release
+// tag" step's outputs instead of rescanning `git tag` itself, so the range fed
+// to git-cliff and the baseline this step compares against can never
+// disagree. A useful side effect is that the step is now a pure function of
+// its environment: these subtests run with no git repository at all.
+func TestReleaseWorkflowResolvesConfiguredDefaultBumpFromSharedPreviousTag(t *testing.T) {
+	script := releaseWorkflowRunBlock(t, "Resolve configured default bump")
+	workspace := t.TempDir() // deliberately not a git repository
+
+	t.Run("accepts a valid greater proposed version", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "github-output")
+		output, err := runBash(workspace, script, map[string]string{
+			"PROPOSED_VERSION": "v0.34.0",
+			"PREFIX":           "v",
+			"DEFAULT_BUMP":     "false",
+			"LATEST_TAG":       "v0.33.2",
+			"PREVIOUS_VERSION": "0.33.2",
+			"GITHUB_OUTPUT":    outputFile,
+		})
+		if err != nil {
+			t.Fatalf("resolve configured default bump: %v\n%s", err, output)
+		}
+		if got := githubOutput(t, outputFile, "new_version"); got != "0.34.0" {
+			t.Fatalf("new_version = %q, want 0.34.0", got)
+		}
+		if got := githubOutput(t, outputFile, "new_tag"); got != "v0.34.0" {
+			t.Fatalf("new_tag = %q, want v0.34.0", got)
+		}
+		if got := githubOutput(t, outputFile, "previous_tag"); got != "v0.33.2" {
+			t.Fatalf("previous_tag = %q, want v0.33.2", got)
+		}
+	})
+
+	t.Run("falls back to default_bump when git-cliff proposed nothing", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "github-output")
+		output, err := runBash(workspace, script, map[string]string{
+			"PROPOSED_VERSION": "v0.33.2", // unchanged: git-cliff found nothing to bump
+			"PREFIX":           "v",
+			"DEFAULT_BUMP":     "patch",
+			"LATEST_TAG":       "v0.33.2",
+			"PREVIOUS_VERSION": "0.33.2",
+			"GITHUB_OUTPUT":    outputFile,
+		})
+		if err != nil {
+			t.Fatalf("resolve configured default bump: %v\n%s", err, output)
+		}
+		if got := githubOutput(t, outputFile, "new_version"); got != "0.33.3" {
+			t.Fatalf("new_version = %q, want 0.33.3", got)
+		}
+	})
+
+	t.Run("stays silent when default_bump is disabled and nothing was proposed", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "github-output")
+		if err := os.WriteFile(outputFile, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		output, err := runBash(workspace, script, map[string]string{
+			"PROPOSED_VERSION": "v0.33.2",
+			"PREFIX":           "v",
+			"DEFAULT_BUMP":     "false",
+			"LATEST_TAG":       "v0.33.2",
+			"PREVIOUS_VERSION": "0.33.2",
+			"GITHUB_OUTPUT":    outputFile,
+		})
+		if err != nil {
+			t.Fatalf("resolve configured default bump: %v\n%s", err, output)
+		}
+		content, err := os.ReadFile(outputFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(content) != 0 {
+			t.Fatalf("GITHUB_OUTPUT = %q, want no output written", content)
+		}
+	})
+
+	t.Run("handles the very first release with no previous tag", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "github-output")
+		output, err := runBash(workspace, script, map[string]string{
+			"PROPOSED_VERSION": "v0.1.0",
+			"PREFIX":           "v",
+			"DEFAULT_BUMP":     "false",
+			"LATEST_TAG":       "",
+			"PREVIOUS_VERSION": "0.0.0",
+			"GITHUB_OUTPUT":    outputFile,
+		})
+		if err != nil {
+			t.Fatalf("resolve configured default bump: %v\n%s", err, output)
+		}
+		if got := githubOutput(t, outputFile, "new_version"); got != "0.1.0" {
+			t.Fatalf("new_version = %q, want 0.1.0", got)
+		}
+		if got := githubOutput(t, outputFile, "previous_tag"); got != "" {
+			t.Fatalf("previous_tag = %q, want empty", got)
+		}
+	})
+}
+
+// initGitRepo creates a git repository with a single commit and the given
+// tags, all pointed at that commit, and returns its path.
+func initGitRepo(t *testing.T, tags ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+		}
+	}
+	run("init", "--initial-branch=main", "-q")
+	run("config", "user.email", "release-test@example.invalid")
+	run("config", "user.name", "Release Test")
+	run("commit", "--allow-empty", "-q", "-m", "chore: bootstrap")
+	for _, tag := range tags {
+		run("tag", tag)
+	}
+	return dir
+}
+
 func TestPublishedArtifactWorkflowValidatesTheExactRequestedTag(t *testing.T) {
 	validateScript := publishedArtifactWorkflowRunBlock(t, "Validate exact release tag and platforms")
 


### PR DESCRIPTION
## Summary

- A real (non-squash) merge to `main` introduces commits reachable from HEAD only through the merge commit's second parent. `git-cliff`'s own auto-detected range for `--bumped-version` can silently drop those commits from the bump calculation and report "nothing to bump" for a landed feat/fix, even though `git-cliff --unreleased` (used to render the changelog body) walks the same history and classifies the same commits correctly.
- Empirically reproduced against `sneat-dev/wb` commit `298b9067c7686a4258b0e59d44d1db5a0e82d50e` (merge of a feat+fix PR): the `Release` workflow ran and succeeded, and cut no tag. Passing git-cliff an explicit `<previous-tag>..HEAD` range for that exact commit correctly computes `v0.47.0`; the auto-detected range computes "nothing to bump".
- Fix: resolve the previous release tag *before* computing the bump (new "Resolve previous release tag" step), and feed it to git-cliff as an explicit range. "Resolve configured default bump" now consumes that shared previous-tag/version instead of rescanning `git tag` itself, so the range fed to git-cliff and the baseline it compares against can never disagree — and as a side effect it's now a pure function of its env, no git repo needed to test it.
- Squash-merge and direct-push landings are single-parent from HEAD's perspective either way and are unaffected. The very first release (no previous tag yet) still gets an empty range, falling back to full-history processing exactly as before.
- The external `workflow_call` interface (inputs/outputs/secrets) is unchanged, so this is backward-compatible for every existing caller of this reusable workflow (sneat-dev/wb and others).

## Why this couldn't be pinned as a small isolated fixture

The auto-detect-vs-explicit-range discrepancy did not reproduce against small synthetic fixtures of the same merge topology (tried up to 30 synthetic prior releases) — it only reproduced against the real `sneat-dev/wb` repository's actual ~320-commit/~100-tag history. That's undocumented `git-cliff` behavior this module can't cheaply reconstruct at fixture scale. What *is* pinned at fixture scale is the actual fix: an explicit range correctly bumps a merge-introduced feat to a minor version, and correctly cuts nothing for a merge introducing only docs/chores — see the new `release_calculator_regression` fixtures in `ci.yml`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, including 4 new subtests for "Resolve previous release tag" and 4 for "Resolve configured default bump")
- [x] `go test ./... -coverprofile=...` — coverage unchanged at 100.0% of statements
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `actionlint` on all four workflow files — clean
- [x] Locally reproduced the exact `ci.yml` fixture + git-cliff invocations (pinned `git-cliff` v2.13.1) end-to-end outside the Action runner to confirm `v0.2.0` for the merge-feat fixture and `v0.1.0` (unchanged) for the merge-chore fixture, and confirmed the pre-existing `v0-breaking`/`docs-only` fixtures are unaffected
- [ ] CI green on this PR (watching in foreground)

Fixes sneat-dev/wb#160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFsyYhYi9h9Am1JbAMxuhv