### PR TITLE
build: use Go 1.26 with Go 1.27 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/strongo/go-ci-action
 
-go 1.24.1
+go 1.26.0
+
+toolchain go1.27.0


### PR DESCRIPTION
Sets the Go language version to 1.26.0 for CodeQL compatibility and pins toolchain go1.27.0.